### PR TITLE
 Setting Barnard as default for binary testing and adding Barnard model params

### DIFF
--- a/R/statistical_tests_and_estimates.R
+++ b/R/statistical_tests_and_estimates.R
@@ -137,22 +137,38 @@ two_samp_cont_test <- function(x, y, method = c('wilcox', 't.test'), paired = FA
 
 #' Binary (Response) Variable Compared to Binary (Group) Variable Test (VISC)
 #'
-#' Either Barnard, Fisher's, or Chi-sq test performed for unpaired data and McNemar's test for paired data
+#' Either Barnard, Fisher's, or Chi-sq test performed for unpaired data and
+#'   McNemar's test for paired data
 #'
 #' @param x numeric vector (can include NA values).
-#' @param y vector with only 2 levels (can include NA values unless \code{method = 'mcnemar'}).
-#' @param method what test to run, "barnard" (default), "fisher" ,"chi.sq" , or "mcnemar")
-#' @param barnard_method 	indicates the Barnard method for finding tables as or more extreme than the observed table: must be either "Z-pooled", "Z-unpooled", "Santner and Snell", "Boschloo", "CSM", "CSM approximate", or "CSM modified". Only used when \code{method = 'barnard'}
-#' @param alternative a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less". You can specify just the initial letter. Only "two.sided" available for \code{method = 'chi.sq' or 'mcnemar'}
-#' @param verbose a logical variable indicating if warnings and messages should be displayed.
-#' @param ... other parameters to pass to Exact::exact.test when running Barnard test
+#' @param y vector with only 2 levels (can include NA values unless
+#'   \code{method = 'mcnemar'}).
+#' @param method what test to run, "barnard" (default), "fisher" ,
+#'   "chi.sq" , or "mcnemar")
+#' @param barnard_method 	indicates the Barnard method for finding tables as or
+#'   more extreme than the observed table: must be either "Z-pooled",
+#'  "Z-unpooled", "Santner and Snell", "Boschloo", "CSM", "CSM approximate", or
+#'  "CSM modified". Only used when \code{method = 'barnard'}
+#' @param alternative a character string specifying the alternative hypothesis,
+#'   must be one of "two.sided" (default), "greater" or "less". You can specify
+#'   just the initial letter. Only "two.sided" available for
+#'   \code{method = 'chi.sq' or 'mcnemar'}
+#' @param verbose a logical variable indicating if warnings and messages should
+#'   be displayed.
+#' @param ... other parameters to pass to Exact::exact.test when running
+#'   Barnard test
 #' @return p-value for comparing x at the different levels of y.
 #' @details
 #'
 #'
-#' For one sided tests if \code{y} is a factor variable the level order is respected, otherwise the levels will set to alphabetical order (i.e. if \code{alternative = less} then testing a < b ).
+#' For one sided tests if \code{y} is a factor variable the level order is ]
+#' respected, otherwise the levels will set to alphabetical order (i.e. if
+#' \code{alternative = less} then testing a < b ).
 #'
-#' If \code{method = 'mcnemar'} assumes the first observations of the first group matches the first observation of the second group, and so on. Also if \code{method = 'mcnemar'} then \code{y} must have the same number of samples for each level.
+#' If \code{method = 'mcnemar'} assumes the first observations of the first
+#' group matches the first observation of the second group, and so on. Also if
+#' \code{method = 'mcnemar'} then \code{y} must have the same number of samples
+#' for each level.
 #'
 #' @examples
 #'
@@ -169,33 +185,53 @@ two_samp_cont_test <- function(x, y, method = c('wilcox', 't.test'), paired = FA
 
 
 two_samp_bin_test <- function(x, y, method = c('barnard', 'fisher' ,'chi.sq' , 'mcnemar'),
-                              barnard_method = c("z-pooled", "z-unpooled", "boschloo", "santner and snell", "csm", "csm approximate", "csm modified"),
-                              alternative = c("two.sided", "less", "greater"), verbose = FALSE, ...){
+                              barnard_method = c("z-pooled", "z-unpooled", "boschloo",
+                                                 "santner and snell", "csm",
+                                                 "csm approximate", "csm modified"),
+                              alternative = c("two.sided", "less", "greater"),
+                              verbose = FALSE, ...){
   method <- match.arg(method)
   barnard_method <- match.arg(barnard_method)
   alternative <- match.arg(alternative)
-  if (method == 'chi.sq' & alternative != 'two.sided') stop('When "method" is chi.sq then "alternative" must be two.sided')
-  if (method == 'mcnemar' & alternative != 'two.sided') stop('When "method" is mcnemar then "alternative" must be two.sided')
+  if (method == 'chi.sq' & alternative != 'two.sided')
+    stop('When "method" is chi.sq then "alternative" must be two.sided')
+  if (method == 'mcnemar' & alternative != 'two.sided')
+    stop('When "method" is mcnemar then "alternative" must be two.sided')
   .check_binary_input(x)
   .check_binary_input(y, paired = ifelse(method == 'mcnemar', TRUE, FALSE))
   y <- droplevels(factor(y))
 
   # Removing cases where x and y are both NA and returning p-value where no complete cases or only one distinct value
-  rm_na_and_check_output <- .rm_na_and_check(x, y, x_type = ifelse(method == 'barnard', 'fixed_binary', 'binary'), y_type = 'binary', verbose = verbose)
-  if (is.data.frame(rm_na_and_check_output)) data_here <- rm_na_and_check_output else return(rm_na_and_check_output)
+  rm_na_and_check_output <-
+    .rm_na_and_check(x, y,
+                     x_type = ifelse(method == 'barnard', 'fixed_binary', 'binary'),
+                     y_type = 'binary', verbose = verbose)
+  if (is.data.frame(rm_na_and_check_output))
+    data_here <- rm_na_and_check_output else
+      return(rm_na_and_check_output)
 
   if (method == 'barnard') {
     # table needs to have grp variable (y) first
-    pval_out <- as.double(Exact::exact.test(table(data_here[, c('y', 'x')]), method = barnard_method, to.plot = FALSE, alternative = alternative, ...)$p.value)
+    pval_out <- as.double(
+      Exact::exact.test(table(data_here[, c('y', 'x')]),
+                        method = barnard_method, to.plot = FALSE,
+                        alternative = alternative, ...)$p.value)
   }
   if (method == 'fisher') {
-    pval_out <- as.double(stats::fisher.test(data_here$x, data_here$y, alternative = alternative)$p.value)
+    pval_out <- as.double(
+      stats::fisher.test(data_here$x, data_here$y, alternative = alternative)$p.value
+      )
   }
   if (method == 'chi.sq') {
-    pval_out <- as.double(stats::chisq.test(data_here$x, data_here$y)$p.value)
+    pval_out <- as.double(
+      stats::chisq.test(data_here$x, data_here$y)$p.value
+      )
   }
   if (method == 'mcnemar') {
-    pval_out <- as.double(stats::mcnemar.test(data_here$x[data_here$y == levels(data_here$y)[1]], data_here$x[data_here$y == levels(data_here$y)[2]])$p.value)
+    pval_out <- as.double(
+      stats::mcnemar.test(data_here$x[data_here$y == levels(data_here$y)[1]],
+                          data_here$x[data_here$y == levels(data_here$y)[2]])$p.value
+      )
   }
   pval_out
 }

--- a/man/two_samp_bin_test.Rd
+++ b/man/two_samp_bin_test.Rd
@@ -13,28 +13,44 @@ two_samp_bin_test(x, y, method = c("barnard", "fisher", "chi.sq",
 \arguments{
 \item{x}{numeric vector (can include NA values).}
 
-\item{y}{vector with only 2 levels (can include NA values unless \code{method = 'mcnemar'}).}
+\item{y}{vector with only 2 levels (can include NA values unless
+\code{method = 'mcnemar'}).}
 
-\item{method}{what test to run, "barnard" (default), "fisher" ,"chi.sq" , or "mcnemar")}
+\item{method}{what test to run, "barnard" (default), "fisher" ,
+"chi.sq" , or "mcnemar")}
 
-\item{barnard_method}{indicates the Barnard method for finding tables as or more extreme than the observed table: must be either "Z-pooled", "Z-unpooled", "Santner and Snell", "Boschloo", "CSM", "CSM approximate", or "CSM modified". Only used when \code{method = 'barnard'}}
+\item{barnard_method}{indicates the Barnard method for finding tables as or
+ more extreme than the observed table: must be either "Z-pooled",
+"Z-unpooled", "Santner and Snell", "Boschloo", "CSM", "CSM approximate", or
+"CSM modified". Only used when \code{method = 'barnard'}}
 
-\item{alternative}{a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less". You can specify just the initial letter. Only "two.sided" available for \code{method = 'chi.sq' or 'mcnemar'}}
+\item{alternative}{a character string specifying the alternative hypothesis,
+must be one of "two.sided" (default), "greater" or "less". You can specify
+just the initial letter. Only "two.sided" available for
+\code{method = 'chi.sq' or 'mcnemar'}}
 
-\item{verbose}{a logical variable indicating if warnings and messages should be displayed.}
+\item{verbose}{a logical variable indicating if warnings and messages should
+be displayed.}
 
-\item{...}{other parameters to pass to Exact::exact.test when running Barnard test}
+\item{...}{other parameters to pass to Exact::exact.test when running
+Barnard test}
 }
 \value{
 p-value for comparing x at the different levels of y.
 }
 \description{
-Either Barnard, Fisher's, or Chi-sq test performed for unpaired data and McNemar's test for paired data
+Either Barnard, Fisher's, or Chi-sq test performed for unpaired data and
+  McNemar's test for paired data
 }
 \details{
-For one sided tests if \code{y} is a factor variable the level order is respected, otherwise the levels will set to alphabetical order (i.e. if \code{alternative = less} then testing a < b ).
+For one sided tests if \code{y} is a factor variable the level order is ]
+respected, otherwise the levels will set to alphabetical order (i.e. if
+\code{alternative = less} then testing a < b ).
 
-If \code{method = 'mcnemar'} assumes the first observations of the first group matches the first observation of the second group, and so on. Also if \code{method = 'mcnemar'} then \code{y} must have the same number of samples for each level.
+If \code{method = 'mcnemar'} assumes the first observations of the first
+group matches the first observation of the second group, and so on. Also if
+\code{method = 'mcnemar'} then \code{y} must have the same number of samples
+for each level.
 }
 \examples{
 

--- a/tests/testthat/test_statistical_tests_and_estimates.R
+++ b/tests/testthat/test_statistical_tests_and_estimates.R
@@ -162,97 +162,150 @@ test_that("two_samp_bin_test testing various options (no errors)", {
 
   ###Testing all four options (wilcox/t and paired/unpaired)###
   set.seed(5432322)
-  x <- c(NA, sample(0:1,20,replace = TRUE, prob = c(.65,.25)), sample(0:1,20,replace = TRUE, prob = c(.25,.65)), NA)
+  x <- c(NA, sample(0:1,20,replace = TRUE, prob = c(.65,.25)),
+         sample(0:1,20,replace = TRUE, prob = c(.25,.65)), NA)
   y <- c(rep('a', 20), NA, NA, rep('b', 20))
 
-  paired_data_here <- na.omit(data.frame(a = x[which(y == levels(factor(y))[1])], b = x[which(y == levels(factor(y))[2])]))
+  paired_data_here <- na.omit(
+    data.frame(a = x[which(y == levels(factor(y))[1])],
+               b = x[which(y == levels(factor(y))[2])])
+    )
 
   # Barnard
-  expect_equal(object = two_samp_bin_test(x = x, y = y, method = 'barnard', alternative = 'two.sided'),
-               expected = Exact::exact.test(table(data.frame(y,x)), method = 'Z-pooled', to.plot = FALSE, alternative = 'two.sided')$p.value
-               , tolerance = 1e-8)
-     # Testing barnard_method
-  expect_equal(object = two_samp_bin_test(x = x, y = y, method = 'barnard', barnard_method = 'csm', alternative = 'two.sided'),
-               expected = Exact::exact.test(table(data.frame(y,x)), method = 'csm', to.plot = FALSE, alternative = 'two.sided')$p.value
-               , tolerance = 1e-8)
+  expect_equal(object = two_samp_bin_test(x = x, y = y, method = 'barnard',
+                                          alternative = 'two.sided'),
+               expected = Exact::exact.test(table(data.frame(y,x)),
+                                            method = 'Z-pooled', to.plot = FALSE,
+                                            alternative = 'two.sided')$p.value,
+               tolerance = 1e-8)
+  # Testing barnard_method
+  expect_equal(object = two_samp_bin_test(x = x, y = y, method = 'barnard',
+                                          barnard_method = 'csm',
+                                          alternative = 'two.sided'),
+               expected = Exact::exact.test(table(data.frame(y,x)),
+                                            method = 'csm', to.plot = FALSE,
+                                            alternative = 'two.sided')$p.value,
+               tolerance = 1e-8)
      # Testing ... (i.e. npNumbers)
-  expect_equal(object = two_samp_bin_test(x = x, y = y, method = 'barnard', barnard_method = 'csm', alternative = 'two.sided', npNumbers = 3),
-               expected = Exact::exact.test(table(data.frame(y,x)), method = 'csm', to.plot = FALSE, alternative = 'two.sided', npNumbers = 3)$p.value
-               , tolerance = 1e-8)
+  expect_equal(object = two_samp_bin_test(x = x, y = y, method = 'barnard',
+                                          barnard_method = 'csm',
+                                          alternative = 'two.sided', npNumbers = 3),
+               expected = Exact::exact.test(table(data.frame(y,x)), method = 'csm',
+                                            to.plot = FALSE, alternative = 'two.sided',
+                                            npNumbers = 3)$p.value,
+               tolerance = 1e-8)
   # Fisher
-  expect_equal(object = two_samp_bin_test(x = x, y = y, method = 'fisher', alternative = 'two.sided'),
-               expected = fisher.test(x, y, alternative = 'two.sided')$p.value
-               , tolerance = 1e-8)
+  expect_equal(object = two_samp_bin_test(x = x, y = y, method = 'fisher',
+                                          alternative = 'two.sided'),
+               expected = fisher.test(x, y, alternative = 'two.sided')$p.value,
+               tolerance = 1e-8)
   # Chi-sq
-  expect_equal(object = two_samp_bin_test(x = x, y = y, method = 'chi.sq', alternative = 'two.sided'),
-               expected = chisq.test(x, y)$p.value
-               , tolerance = 1e-8)
+  expect_equal(object = two_samp_bin_test(x = x, y = y, method = 'chi.sq',
+                                          alternative = 'two.sided'),
+               expected = chisq.test(x, y)$p.value,
+               tolerance = 1e-8)
   # McNemar(paired data)
-  expect_equal(object = two_samp_bin_test(x = x[!is.na(y)], y = y[!is.na(y)], method = 'mcnemar', alternative = 'two.sided'),
-               expected = mcnemar.test(paired_data_here$a, paired_data_here$b)$p.value
-               , tolerance = 1e-8)
+  expect_equal(object = two_samp_bin_test(x = x[!is.na(y)], y = y[!is.na(y)],
+                                          method = 'mcnemar', alternative = 'two.sided'),
+               expected = mcnemar.test(paired_data_here$a, paired_data_here$b)$p.value,
+               tolerance = 1e-8)
 
   # Directional, along with factor values
-  expect_equal(object = two_samp_bin_test(x = x, y = y, method = 'barnard', alternative = 'less'),
-               expected = Exact::exact.test(table(data.frame(y,x)), method = 'Z-pooled', to.plot = FALSE, alternative = 'less')$p.value
-               , tolerance = 1e-8)
-  expect_equal(object = two_samp_bin_test(x = factor(x), y = y, method = 'barnard', alternative = 'less'),
-               expected = Exact::exact.test(table(data.frame(y,x)), method = 'Z-pooled', to.plot = FALSE, alternative = 'less')$p.value
-               , tolerance = 1e-8)
-  expect_equal(object = two_samp_bin_test(x = x, y = y, method = 'barnard', alternative = 'greater'),
+  expect_equal(object = two_samp_bin_test(x = x, y = y, method = 'barnard',
+                                          alternative = 'less'),
+               expected = Exact::exact.test(table(data.frame(y,x)), method = 'Z-pooled',
+                                            to.plot = FALSE, alternative = 'less')$p.value,
+               tolerance = 1e-8)
+  expect_equal(object = two_samp_bin_test(x = factor(x), y = y, method = 'barnard',
+                                          alternative = 'less'),
+               expected = Exact::exact.test(table(data.frame(y,x)), method = 'Z-pooled',
+                                            to.plot = FALSE, alternative = 'less')$p.value,
+               tolerance = 1e-8)
+  expect_equal(object = two_samp_bin_test(x = x, y = y, method = 'barnard',
+                                          alternative = 'greater'),
                expected = Exact::exact.test(table(data.frame(y,x)), method = 'Z-pooled', to.plot = FALSE, alternative = 'greater')$p.value
                , tolerance = 1e-8)
-  expect_equal(object = two_samp_bin_test(x = factor(x, levels = 1:0), y = y, method = 'barnard', alternative = 'less'),
-               expected = Exact::exact.test(table(data.frame(y,x)), method = 'Z-pooled', to.plot = FALSE, alternative = 'greater')$p.value
-               , tolerance = 1e-8)
+  expect_equal(object = two_samp_bin_test(x = factor(x, levels = 1:0), y = y,
+                                          method = 'barnard', alternative = 'less'),
+               expected = Exact::exact.test(table(data.frame(y,x)),
+                                            method = 'Z-pooled', to.plot = FALSE,
+                                            alternative = 'greater')$p.value,
+               tolerance = 1e-8)
 })
 
 
 test_that("two_samp_bin_test throwing internal .rm_na_and_check checking errors", {
   set.seed(5432322)
-  x <- c(NA, sample(0:1,10,replace = TRUE, prob = c(.65,.25)), sample(0:1,10,replace = TRUE, prob = c(.25,.65)), NA)
+  x <- c(NA, sample(0:1,10,replace = TRUE, prob = c(.65,.25)),
+         sample(0:1,10,replace = TRUE, prob = c(.25,.65)), NA)
   y <- c(rep('a', 10), NA, NA, rep('b', 10))
 
   #Testing if x and y are different lengths
-  expect_error(two_samp_bin_test(x = rep(0:1,6), y = rep(0:1,5), method = 'barnard'), '"x" and "y" must be the same length')
+  expect_error(two_samp_bin_test(x = rep(0:1,6), y = rep(0:1,5),
+                                 method = 'barnard'),
+               '"x" and "y" must be the same length')
 
   #Testing case where no non-missing pairs
-  expect_equal(object = two_samp_bin_test(x = c(rep(1,20),rep(NA,20)), y = c(rep(NA,20),rep(1,20)), method = 'barnard'), expected = NA)
-  expect_message(object = two_samp_bin_test(x = c(rep(1,20),rep(NA,20)), y = c(rep(NA,20),rep(1,20)), method = 'barnard', verbose = T),
+  expect_equal(object = two_samp_bin_test(x = c(rep(1,20),rep(NA,20)),
+                                          y = c(rep(NA,20),rep(1,20)),
+                                          method = 'barnard'),
+               expected = NA)
+  expect_message(object = two_samp_bin_test(x = c(rep(1,20),rep(NA,20)),
+                                            y = c(rep(NA,20),rep(1,20)),
+                                            method = 'barnard', verbose = T),
                  regexp = 'There are no observations with non-missing values of both "x" and "y", so p=NA returned')
 
   #Testing case where all x have same value
-  expect_equal(object = two_samp_bin_test(x = rep(1,22), y = y, method = 'barnard'), expected = 1)
-  expect_message(object = two_samp_bin_test(x = rep(1,22), y = y, method = 'barnard', verbose = T),
+  expect_equal(object = two_samp_bin_test(x = rep(1,22), y = y,
+                                          method = 'barnard'),
+               expected = 1)
+  expect_message(object = two_samp_bin_test(x = rep(1,22), y = y,
+                                            method = 'barnard', verbose = T),
                  regexp = '"x" only has 1 distinct value when considering non-missing values of "y", so p=1 returned')
 
   #Testing case where all y have same value
-  expect_equal(object = two_samp_bin_test(x = x, y = rep(1,22), method = 'barnard'), expected = NA)
-  expect_message(object = two_samp_bin_test(x = x, y = rep(1,22), method = 'barnard', verbose = T),
+  expect_equal(object = two_samp_bin_test(x = x, y = rep(1,22),
+                                          method = 'barnard'),
+               expected = NA)
+  expect_message(object = two_samp_bin_test(x = x, y = rep(1,22),
+                                            method = 'barnard', verbose = T),
                  regexp = '"y" only has 1 level when considering non-missing values of "x", so p=NA returned')
 })
 
 test_that("two_samp_bin_test throwing internal input checking errors", {
   set.seed(5432322)
-  x <- c(sample(0:1,10,replace = TRUE, prob = c(.65,.25)), sample(0:1,10,replace = TRUE, prob = c(.25,.65)))
+  x <- c(sample(0:1,10,replace = TRUE, prob = c(.65,.25)),
+         sample(0:1,10,replace = TRUE, prob = c(.25,.65)))
   y <- c(rep('a', 10), rep('b', 10))
   my_matrix <- matrix(1:10,nrow = 2)
 
   #Checking x
-  expect_error(two_samp_bin_test(my_matrix, y = y, method = 'barnard'), '"x" must be a vector \\(one-dimensional object\\)')
-  expect_error(two_samp_bin_test(x = numeric(0), y = y, method = 'barnard'), '"x" length must be > 0')
-  expect_error(two_samp_bin_test(c(NA,NA,NA), y, method = 'barnard'), '"x" must have at least one non-NA value')
-  expect_error(two_samp_bin_test(letters[1:5],y, method = 'barnard'), '"x" cannot have more than 2 distinct values')
+  expect_error(two_samp_bin_test(my_matrix, y = y, method = 'barnard'),
+               '"x" must be a vector \\(one-dimensional object\\)')
+  expect_error(two_samp_bin_test(x = numeric(0), y = y, method = 'barnard'),
+               '"x" length must be > 0')
+  expect_error(two_samp_bin_test(c(NA,NA,NA), y, method = 'barnard'),
+               '"x" must have at least one non-NA value')
+  expect_error(two_samp_bin_test(letters[1:5],y, method = 'barnard'),
+               '"x" cannot have more than 2 distinct values')
 
   #Checking y
-  expect_error(two_samp_bin_test(x, my_matrix, method = 'barnard'), '"y" must be a vector \\(one-dimensional object\\)')
-  expect_error(two_samp_bin_test(x,numeric(0), method = 'barnard'), '"y" length must be > 0')
-  expect_error(two_samp_bin_test(x,c(NA,NA,NA), method = 'barnard'), '"y" must have at least one non-NA value')
-  expect_error(two_samp_bin_test(x,1:10, method = 'barnard'), '"y" cannot have more than 2 distinct values')
+  expect_error(two_samp_bin_test(x, my_matrix, method = 'barnard'),
+               '"y" must be a vector \\(one-dimensional object\\)')
+  expect_error(two_samp_bin_test(x,numeric(0), method = 'barnard'),
+               '"y" length must be > 0')
+  expect_error(two_samp_bin_test(x,c(NA,NA,NA), method = 'barnard'),
+               '"y" must have at least one non-NA value')
+  expect_error(two_samp_bin_test(x,1:10, method = 'barnard'),
+               '"y" cannot have more than 2 distinct values')
 
   #Testing paired errors
-  expect_error(two_samp_bin_test(x = c(NA,rep(0:1,4),0), y = c(rep(0:1,4),0,NA), method = 'mcnemar'), 'When "paired" = TRUE "y" cannot have missing values')
-  expect_error(two_samp_bin_test(x = c(NA,rep(0:1,4),0), y = c(rep(0:1,5),1), method = 'mcnemar'), 'When "paired" = TRUE "y" must have the same number of samples for each level')
+  expect_error(two_samp_bin_test(x = c(NA,rep(0:1,4),0),
+                                 y = c(rep(0:1,4),0,NA), method = 'mcnemar'),
+               'When "paired" = TRUE "y" cannot have missing values')
+  expect_error(two_samp_bin_test(x = c(NA,rep(0:1,4),0),
+                                 y = c(rep(0:1,5),1), method = 'mcnemar'),
+               'When "paired" = TRUE "y" must have the same number of samples for each level')
 })
 
 


### PR DESCRIPTION
Changes to `two_samp_bin_test()`. 

1) Made barnard test the default
2) Added specific barnard test params to include

Test cases were also added to capture new functionality 