### PR TITLE
Remove {devtools} dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: VISCfunctions
 Type: Package
 Title: VISC STP/SRA functions
-Version: 1.1.3
+Version: 1.1.4
 Date: 2019-06-05
 Authors@R: c(person("Bryan", "Mayer", ,"bmayer@fredhutch.org", "aut"),
              person("Monica", "Gerber", ,"mgerber@fredhutch.org", "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,6 @@ Imports:
     car,
     coin,
     data.table,
-    devtools (>= 2.0.0),
     dplyr (>= 0.8.1),
     Exact,
     git2r,

--- a/vignettes/Overview.Rmd
+++ b/vignettes/Overview.Rmd
@@ -93,7 +93,7 @@ cred = git2r::cred_ssh_key(
 	privatekey = "MYPATH/.ssh/id_rsa")
 
 # Installing VISCfunctions from GitHub
-devtools::install_git(
+remotes::install_git(
   "https://github.com/FredHutch/VISCfunctions.git", 
   credentials = cred)
 ```
@@ -122,7 +122,7 @@ cred = git2r::cred_ssh_key(
 	publickey = "MYPATH/.ssh/id_rsa.pub", 
 	privatekey = "MYPATH/.ssh/id_rsa")
 
-devtools::install_git(
+remotes::install_git(
   "https://github.com/FredHutch/scharpTemplates.git", 
   credentials = cred)
 ```


### PR DESCRIPTION
{devtools} is not used in the package explicitly, and therefore having it as a dependency is not necessary. It adds bloat to the install.

Could also move to "suggests" if it is decided that we should keep it in to ensure folks follow testing rules.

(It also blocks FredHutch/scharputils#31)