### PR TITLE
Hotfix/pair no comp bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: VISCfunctions
 Type: Package
 Title: VISC STP/SRA functions
-Version: 1.2.1
-Date: 2021-06-02
+Version: 1.2.2
+Date: 2021-10-29
 Authors@R: c(person("Bryan", "Mayer", ,"bmayer@fredhutch.org", "aut"),
              person("Monica", "Gerber", ,"mgerber@fredhutch.org", "aut"),
              person("Celia", "Mahoney", ,"cmahoney@fredhutch.org", "aut"),
@@ -42,5 +42,5 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# VISCfunctions 1.2.2
+
+* Fixed bug in `pairwise_test_cont()` to properly catch paired comparisons where no paired data points exist.
+
 # VISCfunctions 1.2.1
 
 * `pairwise_test_cor()` is now named `cor_test_pairs()`. The function `cor_test_pairs()` now returns a data.frame with information on any ties in each variable instead of number of unique values.

--- a/R/pairwise_comparisons.R
+++ b/R/pairwise_comparisons.R
@@ -230,6 +230,12 @@ pairwise_test_cont <- function(
         j_data <-
           data.frame(y = x[group == j_group], id = id[group == j_group])
         data_here <- stats::na.omit(merge(i_data, j_data, by = 'id'))
+        print(data_here)
+        if (nrow(data_here) == 0) {
+          if (verbose)
+            message('No paired samples for levels', i_group, ' and ', j_group)
+          next()
+        }
         i_vals <- data_here$x
         j_vals <- data_here$y
         vals_here <-  c(i_vals, j_vals)
@@ -324,6 +330,7 @@ pairwise_test_cont <- function(
   }
 
   results <- do.call(base::rbind, results_list)
+  if (nrow(results) == 0) stop('No comparisons could be made.')
 
   # Pasting together stats
   pasted_results <- paste_tbl_grp(

--- a/R/pairwise_comparisons.R
+++ b/R/pairwise_comparisons.R
@@ -230,10 +230,9 @@ pairwise_test_cont <- function(
         j_data <-
           data.frame(y = x[group == j_group], id = id[group == j_group])
         data_here <- stats::na.omit(merge(i_data, j_data, by = 'id'))
-        print(data_here)
         if (nrow(data_here) == 0) {
           if (verbose)
-            message('No paired samples for levels', i_group, ' and ', j_group)
+            message('No paired samples for levels ', i_group, ' and ', j_group)
           next()
         }
         i_vals <- data_here$x
@@ -329,8 +328,9 @@ pairwise_test_cont <- function(
     }
   }
 
+  if (length(results_list) == 0) return(NULL)
+
   results <- do.call(base::rbind, results_list)
-  if (nrow(results) == 0) stop('No comparisons could be made.')
 
   # Pasting together stats
   pasted_results <- paste_tbl_grp(

--- a/tests/testthat/test_pairwise_comparisons.R
+++ b/tests/testthat/test_pairwise_comparisons.R
@@ -539,7 +539,15 @@ test_that("pairwise_comparisons_bin error catching and messages", {
 
   expect_message(object = pairwise_test_cont(x = c(NA,1,1,NA), group = c(0,0,1,1),
                                              verbose = TRUE),
-               regexp = 'x does not have at least 3 non missing per group, so no test run \\(MagnitudeTest=NA returned\\)')
+                 regexp = 'x does not have at least 3 non missing per group, so no test run \\(MagnitudeTest=NA returned\\)')
+
+  expect_message(object = pairwise_test_cont(x = c(NA,1,1,NA), group = c(0,0,1,1),
+                                             paired = TRUE, id = c('a','b','a','b'),
+                                             verbose = TRUE),
+                 regexp = 'No paired samples for levels 0 and 1')
+
+  expect_null(object = pairwise_test_cont(x = c(NA,1,1,NA), group = c(0,0,1,1),
+                                             paired = TRUE, id = c('a','b','a','b')))
 
 })
 

--- a/tests/testthat/test_statistical_tests_and_estimates.R
+++ b/tests/testthat/test_statistical_tests_and_estimates.R
@@ -180,17 +180,17 @@ test_that("two_samp_bin_test testing various options (no errors)", {
                tolerance = 1e-8)
   # Testing barnard_method
   expect_equal(object = two_samp_bin_test(x = x, y = y, method = 'barnard',
-                                          barnard_method = 'csm',
+                                          barnard_method = 'boschloo',
                                           alternative = 'two.sided'),
                expected = Exact::exact.test(table(data.frame(y,x)),
-                                            method = 'csm', to.plot = FALSE,
+                                            method = 'boschloo', to.plot = FALSE,
                                             alternative = 'two.sided')$p.value,
                tolerance = 1e-8)
      # Testing ... (i.e. npNumbers)
   expect_equal(object = two_samp_bin_test(x = x, y = y, method = 'barnard',
-                                          barnard_method = 'csm',
+                                          barnard_method = 'boschloo',
                                           alternative = 'two.sided', npNumbers = 3),
-               expected = Exact::exact.test(table(data.frame(y,x)), method = 'csm',
+               expected = Exact::exact.test(table(data.frame(y,x)), method = 'boschloo',
                                             to.plot = FALSE, alternative = 'two.sided',
                                             npNumbers = 3)$p.value,
                tolerance = 1e-8)


### PR DESCRIPTION
adding error catching for paired comparisons where there are no paired data points.

also changed a test method for Barnard's since "csm" method now requires an additional dependency.