### PR TITLE
Shorten git hash in reproducibility table

### DIFF
--- a/R/reproducibility_tables.R
+++ b/R/reproducibility_tables.R
@@ -195,6 +195,12 @@ get_session_info <- function(){
 
   # Replacing @ with # in source
   my_session_info2$source <- gsub('\\(@', '(', my_session_info2$source)
+  # Use short git hash
+  my_session_info2$source <- sub(
+    '([@][0-9a-f]{7})[0-9a-f]{33}',
+    '\\1',
+    my_session_info2$source
+  )
 
   list(platform_table = my_session_info1, packages_table = my_session_info2)
 }

--- a/R/reproducibility_tables.R
+++ b/R/reproducibility_tables.R
@@ -193,8 +193,6 @@ get_session_info <- function(){
     my_session_info2$data.version[is.na(my_session_info2$data.version)] <- '' else
       my_session_info2 <- my_session_info2[, -match('data.version', colnames(my_session_info2))]
 
-  # Replacing @ with # in source
-  my_session_info2$source <- gsub('\\(@', '(', my_session_info2$source)
   # Use short git hash
   # find '@' followed by 40 hex digits,
   # and substitute with the '@' and the first 7 hex digits in ()-captured group.

--- a/R/reproducibility_tables.R
+++ b/R/reproducibility_tables.R
@@ -196,6 +196,8 @@ get_session_info <- function(){
   # Replacing @ with # in source
   my_session_info2$source <- gsub('\\(@', '(', my_session_info2$source)
   # Use short git hash
+  # find '@' followed by 40 hex digits,
+  # and substitute with the '@' and the first 7 hex digits in ()-captured group.
   my_session_info2$source <- sub(
     '([@][0-9a-f]{7})[0-9a-f]{33}',
     '\\1',


### PR DESCRIPTION
This shortens the git hash in the reproducibility table from 40 to 7.  7 is the standard abbreviated hash length used by GitHub and by the git command line tools (e.g., `git log --oneline`).

It's not clear to me why the line above my change is replacing `(@` with `(`, but that pattern does not seem to be matched in my testing, so it looks like it is not currently doing anything.  Maybe one of you reviewers will know its intent and whether we should leave it or remove it?

@kelliemac, I'm just seeing now that you also have a branch here that shortens the hash, so this might be partially duplicating that?