### PR TITLE
Suppress warnings from get_full_name() when fragile caught system calls fail

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # VISCfunctions (development version)
 
+* Suppress warning from get_full_name() when fragile ldapsearch system call fails on Linux and macOS (#96)
+
 # VISCfunctions 1.2.3
 
 * Use shorter git hash in reproducibility table (#92)

--- a/R/reproducibility_tables.R
+++ b/R/reproducibility_tables.R
@@ -35,7 +35,7 @@ get_full_name <- function(id = NULL){
          Linux   = {
            if (is.null(id)) {id <- Sys.getenv("USER")}
            myargs <- paste0("-x -h ldapint.pc.scharp.org -b dc=scharp,dc=org uid=", id)
-           user <- tryCatch({system2("ldapsearch", args = myargs, stdout = TRUE)},
+           user <- tryCatch({system2("ldapsearch", args = myargs, stdout = TRUE, stderr = FALSE)},
                             warning = function(w){NULL},
                             error = function(e){NULL})
            user <- user[grep("cn:", user)]
@@ -48,7 +48,7 @@ get_full_name <- function(id = NULL){
          Darwin  = {
            if (is.null(id)) {id <- Sys.getenv("USER")}
            myargs <- paste0("-x -h ldapint.pc.scharp.org -b dc=scharp,dc=org uid=", id)
-           user <- tryCatch({system2("ldapsearch", args = myargs, stdout = TRUE)},
+           user <- tryCatch({system2("ldapsearch", args = myargs, stdout = TRUE, stderr = FALSE)},
                             warning = function(w){NULL},
                             error = function(e){NULL})
            user <- user[grep("cn:", user)]


### PR DESCRIPTION
Addresses https://github.com/FredHutch/VISCtemplates/issues/245.