### PR TITLE
bug fix with tests for paired

### DIFF
--- a/R/pairwise_comparisons.R
+++ b/R/pairwise_comparisons.R
@@ -240,6 +240,7 @@ pairwise_test_cont <- function(
         vals_here <-  c(i_vals, j_vals)
         groups_here <-  c(rep(i_group, nrow(data_here)),
                           rep(j_group, nrow(data_here)))
+        groups_here <- droplevels(factor(groups_here, levels = levels_here))
 
       } else {
 
@@ -611,6 +612,7 @@ pairwise_test_bin <- function(x,
         vals_here <-  c(i_vals, j_vals)
         groups_here <-  c(rep(i_group, nrow(data_here)),
                           rep(j_group, nrow(data_here)))
+        groups_here <- droplevels(factor(groups_here, levels = levels_here))
       } else {
         i_vals <- x[group == i_group]
         j_vals <- x[group == j_group]


### PR DESCRIPTION
Fixed bug in #102. Also found similar bug in `pairwise_test_cont()`. Fix was straightforward, just needed to make group variable a factor with set levels. Added tests based on Gabby's reprex