### PR TITLE
Reduce number of dependencies

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Install statsrv packages
         if: ${{ matrix.config.r == '4.0.4' }}
         run: |
-          sudo apt install -y libx11-dev make libgit2-dev libssh2-1-dev libssl-dev zlib1g-dev libicu-dev libpng-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libxml2-dev libcurl4-openssl-dev
+          sudo apt install -y make libicu-dev libpng-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libxml2-dev libcurl4-openssl-dev libssl-dev
           R -q -e 'utils::install.packages("remotes")'
           R -q -e 'remotes::install_version("htmlTable", "2.4.1")'
           R -q -e 'remotes::install_version("scales", "1.3.0")'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,6 @@ Suggests:
     dplyr,
     tidyr,
     pracma,
-    rmarkdown,
     testthat
 VignetteBuilder: 
     knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,17 +1,20 @@
-Package: VISCfunctions
 Type: Package
+Package: VISCfunctions
 Title: VISC STP/SRA functions
 Version: 1.3.0.9000
-Authors@R: c(person("Bryan", "Mayer", ,"bmayer@fredhutch.org", "aut"),
-             person("Monica", "Gerber", ,"mgerber@fredhutch.org", "aut"),
-             person("Celia", "Mahoney", ,"cmahoney@fredhutch.org", "aut"),
-             person("Ellis", "Hughes", ,"ehhughes@fredhutch.org", "aut"),
-             person("Heather", "Bouzek", ,"hbouzek@fredhutch.org", "aut"),
-             person("Jimmy", "Fulp", ,"wfulp@fredhutch.org", c("aut", "cre"))
-             )
-Description: Statistical, data processing, and annotation functions for VISC.
+Authors@R: c(
+    person("Bryan", "Mayer", , "bmayer@fredhutch.org", role = "aut"),
+    person("Monica", "Gerber", , "mgerber@fredhutch.org", role = "aut"),
+    person("Celia", "Mahoney", , "cmahoney@fredhutch.org", role = "aut"),
+    person("Ellis", "Hughes", , "ehhughes@fredhutch.org", role = "aut"),
+    person("Heather", "Bouzek", , "hbouzek@fredhutch.org", role = "aut"),
+    person("Jimmy", "Fulp", , "wfulp@fredhutch.org", role = c("aut", "cre"))
+  )
+Description:
+    Statistical, data processing, and annotation functions for VISC.
 License: MIT + file LICENSE
-Depends: R (>= 2.10)
+Depends:
+    R (>= 2.10)
 Imports: 
     binom,
     coin,
@@ -23,14 +26,14 @@ Imports:
     survival,
     withr
 Suggests: 
-    ggplot2,
     dplyr,
-    tidyr,
+    ggplot2,
     pracma,
-    testthat
+    testthat,
+    tidyr
 VignetteBuilder: 
     knitr
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.3.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,8 +29,7 @@ Suggests:
     tidyr,
     pracma,
     rmarkdown,
-    testthat,
-    tibble
+    testthat
 VignetteBuilder: 
     knitr
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,6 @@ Suggests:
     pracma,
     rmarkdown,
     testthat,
-    stringr,
     tibble
 VignetteBuilder: 
     knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ License: MIT + file LICENSE
 Depends: R (>= 2.10)
 Imports: 
     binom,
-    coin (>= 1.3-1),
+    coin,
     Exact,
     kableExtra,
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,6 @@ Imports:
     kableExtra,
     knitr,
     lifecycle,
-    purrr,
     sessioninfo,
     survival,
     withr

--- a/R/reproducibility_tables.R
+++ b/R/reproducibility_tables.R
@@ -187,7 +187,15 @@ get_session_info <- function(libpath = FALSE){
     data.frame(package = package,
                version = loadedversion,
                # Pulling in Data Version numbers
-               data.version = purrr::map_chr(package, utils::packageDescription, fields = 'DataVersion'),
+               data.version = vapply(
+                 package,
+                 function(x){
+                   as.character(
+                     utils::packageDescription(x, fields = 'DataVersion')
+                   )
+                 },
+                 "",
+                 USE.NAMES = FALSE),
                date = date,
                source = source,
                libpath = library)

--- a/tests/testthat/test_pairwise_comparisons.R
+++ b/tests/testthat/test_pairwise_comparisons.R
@@ -365,7 +365,6 @@ test_that("pairwise_comparisons_bin testing two groups", {
 # test pairwise_test_cont. Using paste_tbl_grp and two_samp_cont_test in testing since these functions are testing elsewhere
 test_that("pairwise_comparisons testing multiple groups", {
   library(tidyr)
-  library(purrr)
 
   test_single_comp <- function(x, group, Group1, Group2) {
     test_data <- data.frame(x = x[!is.na(x)],
@@ -956,7 +955,6 @@ test_that("cor_test_pairs testing two groups", {
 # test cor_test_pairs Using paste_tbl_grp and cor_test in testing since these functions are testing elsewhere
 test_that("cor_test_pairs testing multiple groups", {
   library(tidyr)
-  library(purrr)
   library(dplyr)
 
   test_single_comp <- function(data_in) {

--- a/tests/testthat/test_pairwise_comparisons.R
+++ b/tests/testthat/test_pairwise_comparisons.R
@@ -612,7 +612,7 @@ test_that("pairwise_comparisons_bin testing two groups", {
 
   names(test_pasting) <- c('Comparison', 'ResponseStats')
 
-  purrr::walk(c("barnard", "fisher", "chi.sq"),
+  lapply(c("barnard", "fisher", "chi.sq"),
               function(method_in){
                 testing_results <- data.frame(test_pasting,
                                               ResponseTest  = two_samp_bin_test(x = x,

--- a/vignettes/Overview.Rmd
+++ b/vignettes/Overview.Rmd
@@ -149,7 +149,7 @@ associated documentation that can be viewed using `?` (i.e `?exampleData_BAMA`).
 data("exampleData_BAMA", "exampleData_NAb", "exampleData_ICS", "CAVD812_mAB")
 
 # Quick view of dataset
-tibble::glimpse(exampleData_BAMA)
+str(exampleData_BAMA)
 ```
 
 

--- a/vignettes/Overview.Rmd
+++ b/vignettes/Overview.Rmd
@@ -157,7 +157,7 @@ tibble::glimpse(exampleData_BAMA)
 # Loading in example datasets
 exampleData_BAMA <- 
   exampleData_BAMA %>% 
-  mutate(antigen = stringr::str_replace_all(antigen, '_', ' '))
+  mutate(antigen = gsub('_', ' ', antigen))
 ```
 
 


### PR DESCRIPTION
- remove explicit dependencies on packages purrr, rmarkdown, stringr, and tibble
- rm newly unneeded apt dependencies from statsrv CI runner
- run desc::normalize() on DESCRIPTION file

Some other dependencies had recently been removed in [PR 107](https://github.com/FredHutch/VISCfunctions/pull/107/files#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231c).