### PR TITLE
use frozen-date CRAN repository to ease R 4.0.4 CI maintenance

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -51,26 +51,22 @@ jobs:
           fancyhdr colortbl soul setspace relsize makecell threeparttable
           threeparttablex environ trimspaces
 
-      - uses: r-lib/actions/setup-r@v2
+      - name: Setup recent R
+        uses: r-lib/actions/setup-r@v2
+        if: ${{ matrix.config.r != '4.0.4' }}
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Install statsrv packages
+      - name: Setup R 4.0.4
+        uses: r-lib/actions/setup-r@v2
         if: ${{ matrix.config.r == '4.0.4' }}
-        run: |
-          sudo apt install -y make libicu-dev libpng-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libxml2-dev libcurl4-openssl-dev libssl-dev
-          R -q -e 'utils::install.packages("remotes")'
-          R -q -e 'remotes::install_version("htmlTable", "2.4.1")'
-          R -q -e 'remotes::install_version("scales", "1.3.0")'
-          R -q -e 'remotes::install_version("Hmisc", "4.5-0")'
-          R -q -e 'remotes::install_version("svglite", "2.1.3")'
-          R -q -e 'remotes::install_github("FredHutch/VISCfunctions", dependencies = TRUE)'
-          R -q -e 'utils::install.packages("rcmdcheck")'
+        with:
+          r-version: ${{ matrix.config.r }}
+          cran: 'https://packagemanager.posit.co/cran/__linux__/noble/2024-04-19'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
-        if: ${{ matrix.config.r != '4.0.4' }}
         with:
           extra-packages: any::rcmdcheck
           needs: check


### PR DESCRIPTION
Obviate manual updates to the R 4.0.4 CI to track dropped support of old R version

cf. 

https://github.com/FredHutch/VISCtemplates/pull/294
https://github.com/FredHutch/DPR2/pull/112

Avoids things like this (purrr just released a new version that drops support for R < 4.1):
https://github.com/FredHutch/VISCfunctions/actions/runs/16273919299/job/45948108830