### PR TITLE
Auto-generate VISCfunctions website with pkgdown/GH actions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,6 @@ CONDUCT.md
 CONTRIBUTING.md
 ^\.github$
 data-raw/
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,49 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown.yaml
+
+permissions: read-all
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ doc
 Meta
 /doc/
 /Meta/
+docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Package: VISCfunctions
 Title: VISC STP/SRA functions
 Version: 1.3.0.9000
 Authors@R: c(
-    person("Bryan", "Mayer", , "bmayer@fredhutch.org", role = c("aut", "cre")),
+    person("Bryan", "Mayer", , "bmayer@fredhutch.org", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-2258-5276")),
     person("Dave", "Slager", , "dslager@fredhutch.org", role = "aut", comment = c(ORCID = "0000-0003-2525-2039")),
     person("Kellie", "MacPhee", , "kmacphee@fredhutch.org", role = "aut"),
     person("Gabrielle", "Lemire", , "glemire@fredhutch.org", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,12 +3,16 @@ Package: VISCfunctions
 Title: VISC STP/SRA functions
 Version: 1.3.0.9000
 Authors@R: c(
-    person("Bryan", "Mayer", , "bmayer@fredhutch.org", role = "aut"),
-    person("Monica", "Gerber", , "mgerber@fredhutch.org", role = "aut"),
-    person("Celia", "Mahoney", , "cmahoney@fredhutch.org", role = "aut"),
-    person("Ellis", "Hughes", , "ehhughes@fredhutch.org", role = "aut"),
-    person("Heather", "Bouzek", , "hbouzek@fredhutch.org", role = "aut"),
-    person("Jimmy", "Fulp", , "wfulp@fredhutch.org", role = c("aut", "cre"))
+    person("Bryan", "Mayer", , "bmayer@fredhutch.org", role = c("aut", "cre")),
+    person("Dave", "Slager", , "dslager@fredhutch.org", role = "aut", comment = c(ORCID = "0000-0003-2525-2039")),
+    person("Kellie", "MacPhee", , "kmacphee@fredhutch.org", role = "aut"),
+    person("Gabrielle", "Lemire", , "glemire@fredhutch.org", role = "aut"),
+    person("Claudio", "Yurdadon", , "cyurdado@fredhutch.org", role = "aut"),
+    person("Monica", "Gerber", , , role = "aut"),
+    person("Celia", "Mahoney", , , role = "aut"),
+    person("Ellis", "Hughes", , , role = "aut", comment = c(ORCID = "0000-0003-0637-4436")),
+    person("Heather", "Bouzek", , , role = "aut"),
+    person("Jimmy", "Fulp", , , role = "aut")
   )
 Description:
     Statistical, data processing, and annotation functions for VISC.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R: c(
     person("Dave", "Slager", , "dslager@fredhutch.org", role = "aut", comment = c(ORCID = "0000-0003-2525-2039")),
     person("Kellie", "MacPhee", , "kmacphee@fredhutch.org", role = "aut"),
     person("Gabrielle", "Lemire", , "glemire@fredhutch.org", role = "aut"),
-    person("Claudio", "Yurdadon", , "cyurdado@fredhutch.org", role = "aut"),
+    person("Claudio", "Yurdadon", , "cyurdado@fredhutch.org", role = "aut", comment = c(ORCID = "0000-0002-4928-2737")),
     person("Monica", "Gerber", , , role = "aut"),
     person("Celia", "Mahoney", , , role = "aut"),
     person("Ellis", "Hughes", , , role = "aut", comment = c(ORCID = "0000-0003-0637-4436")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 1.3.0.9000
 Authors@R: c(
     person("Bryan", "Mayer", , "bmayer@fredhutch.org", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-2258-5276")),
     person("Dave", "Slager", , "dslager@fredhutch.org", role = "aut", comment = c(ORCID = "0000-0003-2525-2039")),
-    person("Kellie", "MacPhee", , "kmacphee@fredhutch.org", role = "aut"),
+    person("Kellie", "MacPhee", , "kmacphee@fredhutch.org", role = "aut", comment = c(ORCID = "0009-0008-0993-4009")),
     person("Gabrielle", "Lemire", , "glemire@fredhutch.org", role = "aut"),
     person("Claudio", "Yurdadon", , "cyurdado@fredhutch.org", role = "aut", comment = c(ORCID = "0000-0002-4928-2737")),
     person("Monica", "Gerber", , , role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,4 +36,5 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
+URL: https://fredhutch.github.io/VISCfunctions/

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,4 @@
+url: https://fredhutch.github.io/VISCfunctions/
+template:
+  bootstrap: 5
+

--- a/man/VISCfunctions-package.Rd
+++ b/man/VISCfunctions-package.Rd
@@ -15,15 +15,19 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Jimmy Fulp \email{wfulp@fredhutch.org}
+\strong{Maintainer}: Bryan Mayer \email{bmayer@fredhutch.org}
 
 Authors:
 \itemize{
-  \item Bryan Mayer \email{bmayer@fredhutch.org}
-  \item Monica Gerber \email{mgerber@fredhutch.org}
-  \item Celia Mahoney \email{cmahoney@fredhutch.org}
-  \item Ellis Hughes \email{ehhughes@fredhutch.org}
-  \item Heather Bouzek \email{hbouzek@fredhutch.org}
+  \item Dave Slager \email{dslager@fredhutch.org} (\href{https://orcid.org/0000-0003-2525-2039}{ORCID})
+  \item Kellie MacPhee \email{kmacphee@fredhutch.org}
+  \item Gabrielle Lemire \email{glemire@fredhutch.org}
+  \item Claudio Yurdadon \email{cyurdado@fredhutch.org}
+  \item Monica Gerber
+  \item Celia Mahoney
+  \item Ellis Hughes (\href{https://orcid.org/0000-0003-0637-4436}{ORCID})
+  \item Heather Bouzek
+  \item Jimmy Fulp
 }
 
 }

--- a/man/VISCfunctions-package.Rd
+++ b/man/VISCfunctions-package.Rd
@@ -22,7 +22,7 @@ Authors:
   \item Dave Slager \email{dslager@fredhutch.org} (\href{https://orcid.org/0000-0003-2525-2039}{ORCID})
   \item Kellie MacPhee \email{kmacphee@fredhutch.org}
   \item Gabrielle Lemire \email{glemire@fredhutch.org}
-  \item Claudio Yurdadon \email{cyurdado@fredhutch.org}
+  \item Claudio Yurdadon \email{cyurdado@fredhutch.org} (\href{https://orcid.org/0000-0002-4928-2737}{ORCID})
   \item Monica Gerber
   \item Celia Mahoney
   \item Ellis Hughes (\href{https://orcid.org/0000-0003-0637-4436}{ORCID})

--- a/man/VISCfunctions-package.Rd
+++ b/man/VISCfunctions-package.Rd
@@ -15,7 +15,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Bryan Mayer \email{bmayer@fredhutch.org}
+\strong{Maintainer}: Bryan Mayer \email{bmayer@fredhutch.org} (\href{https://orcid.org/0000-0003-2258-5276}{ORCID})
 
 Authors:
 \itemize{

--- a/man/VISCfunctions-package.Rd
+++ b/man/VISCfunctions-package.Rd
@@ -20,7 +20,7 @@ Useful links:
 Authors:
 \itemize{
   \item Dave Slager \email{dslager@fredhutch.org} (\href{https://orcid.org/0000-0003-2525-2039}{ORCID})
-  \item Kellie MacPhee \email{kmacphee@fredhutch.org}
+  \item Kellie MacPhee \email{kmacphee@fredhutch.org} (\href{https://orcid.org/0009-0008-0993-4009}{ORCID})
   \item Gabrielle Lemire \email{glemire@fredhutch.org}
   \item Claudio Yurdadon \email{cyurdado@fredhutch.org} (\href{https://orcid.org/0000-0002-4928-2737}{ORCID})
   \item Monica Gerber

--- a/man/VISCfunctions-package.Rd
+++ b/man/VISCfunctions-package.Rd
@@ -7,6 +7,13 @@
 \description{
 Statistical, data processing, and annotation functions for VISC.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://fredhutch.github.io/VISCfunctions/}
+}
+
+}
 \author{
 \strong{Maintainer}: Jimmy Fulp \email{wfulp@fredhutch.org}
 

--- a/man/VISCfunctions.Rd
+++ b/man/VISCfunctions.Rd
@@ -15,15 +15,19 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Jimmy Fulp \email{wfulp@fredhutch.org}
+\strong{Maintainer}: Bryan Mayer \email{bmayer@fredhutch.org}
 
 Authors:
 \itemize{
-  \item Bryan Mayer \email{bmayer@fredhutch.org}
-  \item Monica Gerber \email{mgerber@fredhutch.org}
-  \item Celia Mahoney \email{cmahoney@fredhutch.org}
-  \item Ellis Hughes \email{ehhughes@fredhutch.org}
-  \item Heather Bouzek \email{hbouzek@fredhutch.org}
+  \item Dave Slager \email{dslager@fredhutch.org} (\href{https://orcid.org/0000-0003-2525-2039}{ORCID})
+  \item Kellie MacPhee \email{kmacphee@fredhutch.org}
+  \item Gabrielle Lemire \email{glemire@fredhutch.org}
+  \item Claudio Yurdadon \email{cyurdado@fredhutch.org}
+  \item Monica Gerber
+  \item Celia Mahoney
+  \item Ellis Hughes (\href{https://orcid.org/0000-0003-0637-4436}{ORCID})
+  \item Heather Bouzek
+  \item Jimmy Fulp
 }
 
 }

--- a/man/VISCfunctions.Rd
+++ b/man/VISCfunctions.Rd
@@ -22,7 +22,7 @@ Authors:
   \item Dave Slager \email{dslager@fredhutch.org} (\href{https://orcid.org/0000-0003-2525-2039}{ORCID})
   \item Kellie MacPhee \email{kmacphee@fredhutch.org}
   \item Gabrielle Lemire \email{glemire@fredhutch.org}
-  \item Claudio Yurdadon \email{cyurdado@fredhutch.org}
+  \item Claudio Yurdadon \email{cyurdado@fredhutch.org} (\href{https://orcid.org/0000-0002-4928-2737}{ORCID})
   \item Monica Gerber
   \item Celia Mahoney
   \item Ellis Hughes (\href{https://orcid.org/0000-0003-0637-4436}{ORCID})

--- a/man/VISCfunctions.Rd
+++ b/man/VISCfunctions.Rd
@@ -15,7 +15,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Bryan Mayer \email{bmayer@fredhutch.org}
+\strong{Maintainer}: Bryan Mayer \email{bmayer@fredhutch.org} (\href{https://orcid.org/0000-0003-2258-5276}{ORCID})
 
 Authors:
 \itemize{

--- a/man/VISCfunctions.Rd
+++ b/man/VISCfunctions.Rd
@@ -20,7 +20,7 @@ Useful links:
 Authors:
 \itemize{
   \item Dave Slager \email{dslager@fredhutch.org} (\href{https://orcid.org/0000-0003-2525-2039}{ORCID})
-  \item Kellie MacPhee \email{kmacphee@fredhutch.org}
+  \item Kellie MacPhee \email{kmacphee@fredhutch.org} (\href{https://orcid.org/0009-0008-0993-4009}{ORCID})
   \item Gabrielle Lemire \email{glemire@fredhutch.org}
   \item Claudio Yurdadon \email{cyurdado@fredhutch.org} (\href{https://orcid.org/0000-0002-4928-2737}{ORCID})
   \item Monica Gerber

--- a/man/VISCfunctions.Rd
+++ b/man/VISCfunctions.Rd
@@ -7,6 +7,13 @@
 \description{
 Statistical, data processing, and annotation functions for VISC.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://fredhutch.github.io/VISCfunctions/}
+}
+
+}
 \author{
 \strong{Maintainer}: Jimmy Fulp \email{wfulp@fredhutch.org}
 


### PR DESCRIPTION
Attempt to set up automated github pages website via usethis defaults.

Renders successfully on a local site build with `pkgdown::build_site()`

Needs to make its way into `main` to be deployed onto the github.io website.