### PR TITLE
Add nodename to platform reproducibility table

### DIFF
--- a/R/reproducibility_tables.R
+++ b/R/reproducibility_tables.R
@@ -2,13 +2,17 @@
 #'
 #' For a given ID looks up user name
 #'
-#' @param id ID to look full name up. If null (default) looks up ID of current user
+#' @param id ID to look full name up. If null (default) looks up ID of current
+#'   user
 #'
 #' @return First and Last name associated with ID
 #'
 #' @details
 #'
-#' If \code{id} null, uses system "USERNAME" variable for Windows and "USER" variable for Linux and MACs. Full Name is found in Windows via the \code{net} command, and via ldap search in Linux and MACs. The ldap search will only work on SCHARPs network at Fred Hutching Cancer Research Center.
+#' If \code{id} null, uses system "USERNAME" variable for Windows and "USER"
+#' variable for Linux and MACs. Full Name is found in Windows via the \code{net}
+#' command, and via ldap search in Linux and MACs. The ldap search will only
+#' work on SCHARPs network at Fred Hutching Cancer Research Center.
 #'
 #'
 #' @examples
@@ -66,19 +70,25 @@ get_full_name <- function(id = NULL){
 
 #' Get Reproducibility Tables
 #'
-#' Creating tables used at the end of reports, for reproducibility. Most of the information is based off of sessioninfo::session_info()
+#' Creating tables used at the end of reports, for reproducibility. Most of the
+#' information is based off of sessioninfo::session_info()
 #'
 #'
-#' @return list of length two, containing dataframe of Software Session Information and dataframe of Software Package Version Information
+#' @return list of length two, containing dataframe of Software Session
+#'   Information and dataframe of Software Package Version Information
 #' @param libpath Show R package library path column in packages table
 #'
 #' @details
 #'
 #' Both tables usually printing with \code{kable()} at the end of a report.
 #'
-#' If any loaded packages have a \code{DataVersion} field then the Software Package Version Information will contain a \code{data.version} column.
+#' If any loaded packages have a \code{DataVersion} field then the Software
+#' Package Version Information will contain a \code{data.version} column.
 #'
-#' Full Name is found in Windows via the \code{net} command, and via ldap search in Linux and MACs. The ldap search will only work on SCHARPs network at Fred Hutching Cancer Research Center. If there is an error attempting to get the Full Name, the system usernam will be displayed instead.
+#' Full Name is found in Windows via the \code{net} command, and via ldap search
+#' in Linux and MACs. The ldap search will only work on SCHARPs network at Fred
+#' Hutching Cancer Research Center. If there is an error attempting to get the
+#' Full Name, the system usernam will be displayed instead.
 #'
 #'
 #' @examples
@@ -125,25 +135,34 @@ get_session_info <- function(libpath = FALSE){
   # TABLE 1
   my_session_info1 <- data.frame(
     name = names(platform),
-    value = matrix(unlist(platform), nrow = length(platform)),
-    stringsAsFactors = FALSE)
+    value = matrix(unlist(platform), nrow = length(platform))
+  )
 
-  my_current_input <- ifelse(is.null(ci <- knitr::current_input()), 'No Input File Detected', ci)
-  my_current_input_w_dir <- ifelse(is.null(ci <-  knitr::current_input(dir = TRUE)), 'No Input File Detected', ci)
+  my_current_input <- ifelse(
+    is.null(ci <- knitr::current_input()), 'No Input File Detected', ci
+  )
+  my_current_input_w_dir <- ifelse(
+    is.null(ci <-  knitr::current_input(dir = TRUE)),
+    'No Input File Detected',
+    ci
+  )
 
   file_name <-  data.frame(
     name = 'file name',
-    value = my_current_input,
-    stringsAsFactors = FALSE)
+    value = my_current_input
+  )
 
   # Add user info
   user_info <- data.frame(
     name = 'user',
-    value = username,
-    stringsAsFactors = FALSE)
+    value = username
+  )
 
-  gitremoteorg <- tryCatch(system2("git" ,"remote -v", stdout = TRUE, stderr = FALSE)[1],
-                           error = function(c) '', warning = function(c) '')
+  gitremoteorg <- tryCatch(
+    system2("git" ,"remote -v", stdout = TRUE, stderr = FALSE)[1],
+    error = function(c) '',
+    warning = function(c) ''
+  )
   gitremote <-  substr(gitremoteorg,
                        regexpr("\t", gitremoteorg) + 1,
                        regexpr(" \\(", gitremoteorg) - 1)
@@ -152,14 +171,27 @@ get_session_info <- function(libpath = FALSE){
     # No Remote Connection, so just give absolute path
     folder_info <- data.frame(
       name = 'location',
-      value = ifelse(my_current_input_w_dir != 'No Input File Detected', dirname(my_current_input_w_dir), getwd()),
-      stringsAsFactors = FALSE)
-    my_session_info1 <- rbind(my_session_info1, folder_info, file_name, user_info)
+      value = ifelse(
+        my_current_input_w_dir != 'No Input File Detected',
+        dirname(my_current_input_w_dir), getwd()
+      )
+    )
+    my_session_info1 <- rbind(
+      my_session_info1, folder_info, file_name, user_info
+    )
   } else{
     if (my_current_input_w_dir != 'No Input File Detected') {
 
-      all_git_files <- system2("git" ,"ls-files -co --no-empty-directory --full-name", stdout = TRUE, stderr = FALSE)
-      folder_info_in <- dirname(all_git_files[unlist(lapply(all_git_files, function(xx) grepl(xx, my_current_input_w_dir)))])
+      all_git_files <- system2(
+        "git" ,"ls-files -co --no-empty-directory --full-name",
+        stdout = TRUE, stderr = FALSE
+      )
+      folder_info_in <- dirname(
+        all_git_files[unlist(lapply(
+          all_git_files,
+          function(xx) grepl(xx, my_current_input_w_dir)
+        ))]
+      )
 
     } else {
       folder_info_in <- 'No Input File Location Detected'
@@ -169,15 +201,22 @@ get_session_info <- function(libpath = FALSE){
     # Dropping matching file names that do not match folder path
     folder_info <- data.frame(
       name = 'location',
-      value = folder_info_in,
-      stringsAsFactors = FALSE)
+      value = folder_info_in
+    )
 
     url_info <- data.frame(
       name = 'repo',
-      value = gitremote,
-      stringsAsFactors = FALSE)
+      value = gitremote
+    )
 
-    my_session_info1 <- rbind(my_session_info1, url_info, file_name, folder_info, user_info)
+    nodename_info <- data.frame(
+      name = 'nodename',
+      value = Sys.info()[['nodename']]
+    )
+
+    my_session_info1 <- rbind(
+      nodename_info, my_session_info1, url_info, file_name, folder_info, user_info
+    )
   }
 
 

--- a/R/reproducibility_tables.R
+++ b/R/reproducibility_tables.R
@@ -133,9 +133,15 @@ get_session_info <- function(libpath = FALSE){
   packages <- my_session_info[[2]]
 
   # TABLE 1
-  my_session_info1 <- data.frame(
-    name = names(platform),
-    value = matrix(unlist(platform), nrow = length(platform))
+  my_session_info1 <- rbind(
+    data.frame(
+      name = 'nodename',
+      value = Sys.info()[['nodename']]
+    ),
+    data.frame(
+      name = names(platform),
+      value = matrix(unlist(platform), nrow = length(platform))
+    )
   )
 
   my_current_input <- ifelse(
@@ -209,13 +215,8 @@ get_session_info <- function(libpath = FALSE){
       value = gitremote
     )
 
-    nodename_info <- data.frame(
-      name = 'nodename',
-      value = Sys.info()[['nodename']]
-    )
-
     my_session_info1 <- rbind(
-      nodename_info, my_session_info1, url_info, file_name, folder_info, user_info
+      my_session_info1, url_info, file_name, folder_info, user_info
     )
   }
 

--- a/tests/testthat/test_reproducibility_tables.R
+++ b/tests/testthat/test_reproducibility_tables.R
@@ -17,7 +17,7 @@ test_that("get_session_info() testing", {
 
   # testing dimension
   nrow_expected <- length(sessioninfo::session_info()[[1]]) +
-    ifelse(any(temp_session_info$platform_table$name == "repo"), 4, 3)
+    ifelse(any(temp_session_info$platform_table$name == "repo"), 5, 4)
   expect_equal(object = dim(temp_session_info$platform_table), expected = c(nrow_expected,2))
 
   ncol_expected <- ifelse(any(colnames(temp_session_info$packages_table) == "data.version"), 5, 4)
@@ -31,9 +31,9 @@ test_that("get_session_info() testing", {
 
   # Comparing platform
   expected_platform <- data.frame(
-    name = names(expected_session_info$platform),
-    value = matrix(unlist(expected_session_info$platform), nrow = length(expected_session_info$platform)),
-    stringsAsFactors = FALSE)
+    name = c('nodename', names(expected_session_info$platform)),
+    value = c(Sys.info()[['nodename']], unname(unlist(expected_session_info$platform)))
+  )
   expect_equal(object = temp_session_info$platform_table[match(expected_platform$name, temp_session_info$platform_table$name), ], expected = expected_platform)
 
   # Comparing packages


### PR DESCRIPTION
Add `nodename` to platform reproducibility table.  Closes #120 for HVTN and is also nice in general to have the reproducibility table show which computer code was run on.  Tested locally on Linux and Windows; could use local testing on macOS.

Also shortened some long lines and removed some `stringsAsFactors = FALSE` lines, which have now long been the default, since R 4.0.0 (April 2020).