### PR TITLE
Report attached and loaded packages in reproducibility table

### DIFF
--- a/R/reproducibility_tables.R
+++ b/R/reproducibility_tables.R
@@ -127,10 +127,8 @@ get_session_info <- function(libpath = FALSE){
                                 Sys.getenv("USERNAME"),
                                 Sys.getenv("USER")))
 
-  my_session_info <- sessioninfo::session_info()
-
-  platform <- my_session_info[[1]]
-  packages <- my_session_info[[2]]
+  platform <- sessioninfo::platform_info()
+  packages <- sessioninfo::package_info(pkgs = 'loaded', include_base = FALSE)
 
   # TABLE 1
   my_session_info1 <- rbind(
@@ -222,8 +220,8 @@ get_session_info <- function(libpath = FALSE){
 
 
   # TABLE 2
-  my_session_info2 <- packages[packages$attached,] # Only want attached packages
-  my_session_info2 <- with(my_session_info2, {
+
+  my_session_info2 <- with(packages, {
     data.frame(package = package,
                version = loadedversion,
                # Pulling in Data Version numbers
@@ -238,6 +236,7 @@ get_session_info <- function(libpath = FALSE){
                  USE.NAMES = FALSE),
                date = date,
                source = source,
+               status = ifelse(attached, 'attached', 'loaded'),
                libpath = library)
   })
   if (! libpath) my_session_info2$libpath <- NULL
@@ -247,6 +246,9 @@ get_session_info <- function(libpath = FALSE){
 
   # Use short git hash
   my_session_info2$source <- shorten_git_hash(my_session_info2$source)
+
+  my_session_info2 <- my_session_info2[order(my_session_info2$status),]
+  rownames(my_session_info2) <- NULL
 
   list(platform_table = my_session_info1, packages_table = my_session_info2)
 }

--- a/man/get_full_name.Rd
+++ b/man/get_full_name.Rd
@@ -7,7 +7,8 @@
 get_full_name(id = NULL)
 }
 \arguments{
-\item{id}{ID to look full name up. If null (default) looks up ID of current user}
+\item{id}{ID to look full name up. If null (default) looks up ID of current
+user}
 }
 \value{
 First and Last name associated with ID
@@ -16,7 +17,10 @@ First and Last name associated with ID
 For a given ID looks up user name
 }
 \details{
-If \code{id} null, uses system "USERNAME" variable for Windows and "USER" variable for Linux and MACs. Full Name is found in Windows via the \code{net} command, and via ldap search in Linux and MACs. The ldap search will only work on SCHARPs network at Fred Hutching Cancer Research Center.
+If \code{id} null, uses system "USERNAME" variable for Windows and "USER"
+variable for Linux and MACs. Full Name is found in Windows via the \code{net}
+command, and via ldap search in Linux and MACs. The ldap search will only
+work on SCHARPs network at Fred Hutching Cancer Research Center.
 }
 \examples{
 

--- a/man/get_session_info.Rd
+++ b/man/get_session_info.Rd
@@ -10,17 +10,23 @@ get_session_info(libpath = FALSE)
 \item{libpath}{Show R package library path column in packages table}
 }
 \value{
-list of length two, containing dataframe of Software Session Information and dataframe of Software Package Version Information
+list of length two, containing dataframe of Software Session
+Information and dataframe of Software Package Version Information
 }
 \description{
-Creating tables used at the end of reports, for reproducibility. Most of the information is based off of sessioninfo::session_info()
+Creating tables used at the end of reports, for reproducibility. Most of the
+information is based off of sessioninfo::session_info()
 }
 \details{
 Both tables usually printing with \code{kable()} at the end of a report.
 
-If any loaded packages have a \code{DataVersion} field then the Software Package Version Information will contain a \code{data.version} column.
+If any loaded packages have a \code{DataVersion} field then the Software
+Package Version Information will contain a \code{data.version} column.
 
-Full Name is found in Windows via the \code{net} command, and via ldap search in Linux and MACs. The ldap search will only work on SCHARPs network at Fred Hutching Cancer Research Center. If there is an error attempting to get the Full Name, the system usernam will be displayed instead.
+Full Name is found in Windows via the \code{net} command, and via ldap search
+in Linux and MACs. The ldap search will only work on SCHARPs network at Fred
+Hutching Cancer Research Center. If there is an error attempting to get the
+Full Name, the system usernam will be displayed instead.
 }
 \examples{
 

--- a/tests/testthat/test_reproducibility_tables.R
+++ b/tests/testthat/test_reproducibility_tables.R
@@ -20,14 +20,17 @@ test_that("get_session_info() testing", {
     ifelse(any(temp_session_info$platform_table$name == "repo"), 5, 4)
   expect_equal(object = dim(temp_session_info$platform_table), expected = c(nrow_expected,2))
 
-  ncol_expected <- ifelse(any(colnames(temp_session_info$packages_table) == "data.version"), 5, 4)
+  ncol_expected <- ifelse(any(colnames(temp_session_info$packages_table) == "data.version"), 6, 5)
   expect_equal(object = ncol(temp_session_info$packages_table), expected = ncol_expected)
 
   # test libpath column option produces that column
   expect_true('libpath' %in% names(get_session_info(libpath = TRUE)$packages_table))
 
   ## testing some outputs from sessioninfo::session_info()
-  expected_session_info <- sessioninfo::session_info()
+  expected_session_info <- sessioninfo::session_info(pkgs = 'loaded')
+
+  expected_session_info$packages$status <-
+    ifelse(expected_session_info$packages$attached, 'attached', 'loaded')
 
   # Comparing platform
   expected_platform <- data.frame(
@@ -37,11 +40,12 @@ test_that("get_session_info() testing", {
   expect_equal(object = temp_session_info$platform_table[match(expected_platform$name, temp_session_info$platform_table$name), ], expected = expected_platform)
 
   # Comparing packages
-  expected_packages <- expected_session_info$packages[expected_session_info$packages$attached,]
+  expected_packages <- expected_session_info$packages[order(expected_session_info$packages$status),]
   expected_packages <- data.frame(package = expected_packages$package,
                                  version = expected_packages$loadedversion,
                                  date = expected_packages$date,
                                  source = shorten_git_hash(expected_packages$source),
+                                 status = expected_packages$status,
                                  stringsAsFactors = FALSE)
 
   expect_equal(object = temp_session_info$packages_table, expected = expected_packages)


### PR DESCRIPTION
Inspired by https://github.com/FredHutch/VISCtemplates/pull/314

Suggested review:  Install this branch with `remotes::install_github('FredHutch/VISCfunctions', ref = 'repro_tbl_namespace')`, then knit a test report with VISCtemplates.  The VISCtemplates skeleton will need an adjustment to allow a packages table to carry over onto a second page if needed.