### PR TITLE
Make VISCfunctions depend on R >= 4.1.0

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup recent R
         uses: r-lib/actions/setup-r@v2
-        if: ${{ matrix.config.r != '4.1.0' || matrix.config.r != '4.4.2'}}
+        if: ${{ matrix.config.r != '4.1.0' && matrix.config.r != '4.4.2'}}
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
@@ -62,7 +62,7 @@ jobs:
 
       - name: Setup older R
         uses: r-lib/actions/setup-r@v2
-        if: ${{ matrix.config.r == '4.1.0' || matrix.config.r != '4.4.2'}}
+        if: ${{ matrix.config.r == '4.1.0' || matrix.config.r == '4.4.2'}}
         with:
           r-version: ${{ matrix.config.r }}
           cran: 'https://packagemanager.posit.co/cran/__linux__/noble/2024-04-19'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,7 +22,8 @@ jobs:
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: '4.0.4', pandoc-version: '2.11.4'}
+          - {os: ubuntu-latest,   r: '4.4.2', pandoc-version: '3.2'}
+          - {os: ubuntu-latest,   r: '4.1.0', pandoc-version: '2.11.4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -31,14 +32,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup statsrv pandoc
-        if: ${{ matrix.config.r == '4.0.4' }}
+      - name: Setup custom pandoc version
+        if: ${{ matrix.config.pandoc-version != null }}
         uses: r-lib/actions/setup-pandoc@v2
         with:
           pandoc-version: ${{ matrix.config.pandoc-version }}
 
-      - name: Setup default pandoc
-        if: ${{ matrix.config.r != '4.0.4' }}
+      - name: Setup default pandoc version
+        if: ${{ matrix.config.pandoc-version == null }}
         uses: r-lib/actions/setup-pandoc@v2
 
       - name: Set up tinytex
@@ -53,15 +54,15 @@ jobs:
 
       - name: Setup recent R
         uses: r-lib/actions/setup-r@v2
-        if: ${{ matrix.config.r != '4.0.4' }}
+        if: ${{ matrix.config.r != '4.1.0' || matrix.config.r != '4.4.2'}}
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Setup R 4.0.4
+      - name: Setup older R
         uses: r-lib/actions/setup-r@v2
-        if: ${{ matrix.config.r == '4.0.4' }}
+        if: ${{ matrix.config.r == '4.1.0' || matrix.config.r != '4.4.2'}}
         with:
           r-version: ${{ matrix.config.r }}
           cran: 'https://packagemanager.posit.co/cran/__linux__/noble/2024-04-19'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Description:
     Statistical, data processing, and annotation functions for VISC.
 License: MIT + file LICENSE
 Depends:
-    R (>= 3.5)
+    R (>= 4.1.0)
 Imports: 
     binom,
     coin,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,11 @@
 # VISCfunctions (development version)
 
-* Maintenance of package and CI (#114)
+* Report loaded and attached packages in package reproducibility table (#132)
+* Report nodename in platform reproducibility table (#121)
 * Add B cell example dataset from G001 flow and sequencing file (#108)
+* Maintenance of package and CI (#114, #116, #124)
+* VISCfunctions now depends on R >= 4.1.0 (#134)
+* Auto-generate VISCfunctions pkgdown website with GitHub Actions (#119)
 
 # VISCfunctions 1.3.0
 

--- a/R/collapse_group_row.R
+++ b/R/collapse_group_row.R
@@ -19,8 +19,8 @@
 #'
 #' library(dplyr)
 #' options(knitr.kable.NA = '')
-#' collapse_group_row(sample_df, x, y, z) %>%
-#'  kableExtra::kable() %>%
+#' collapse_group_row(sample_df, x, y, z) |>
+#'  kableExtra::kable() |>
 #'  kableExtra::kable_styling()
 #' @export
 collapse_group_row <- function(.data, ..., reorder_cols = TRUE) {

--- a/R/pairwise_comparisons.R
+++ b/R/pairwise_comparisons.R
@@ -83,8 +83,8 @@
 #' data(exampleData_BAMA)
 #'
 #' ## Group Comparison
-#'group_testing_tibble <- exampleData_BAMA %>%
-#'    group_by(antigen, visitno) %>%
+#'group_testing_tibble <- exampleData_BAMA |>
+#'    group_by(antigen, visitno) |>
 #'    reframe(pairwise_test_cont(x = magnitude,
 #'                               group = group,
 #'                               paired = FALSE,
@@ -97,8 +97,8 @@
 #'
 #'
 #' ## Timepoint Comparison
-#'timepoint_testing_dt <- exampleData_BAMA %>%
-#'                        group_by(antigen, group) %>%
+#'timepoint_testing_dt <- exampleData_BAMA |>
+#'                        group_by(antigen, group) |>
 #'                        reframe(pairwise_test_cont(x = magnitude,
 #'                                                   group = visitno,
 #'                                                   paired = TRUE,
@@ -118,8 +118,8 @@
 #'
 #' ## Group Comparison
 #' # using dplyr
-#'exampleData_ICS %>%
-#'group_by(Stim, Parent, Population, Visit) %>%
+#'exampleData_ICS |>
+#'group_by(Stim, Parent, Population, Visit) |>
 #'reframe(pairwise_test_cont(x = PercentCellNet,
 #'                           group = Group,
 #'                           paired = FALSE,
@@ -133,8 +133,8 @@
 #'                           verbose = TRUE))
 #'
 #' # Timepoint Comparison
-#'timepoint_testing_dt <- exampleData_ICS %>%
-#'                        group_by(Stim, Parent, Population, Group) %>%
+#'timepoint_testing_dt <- exampleData_ICS |>
+#'                        group_by(Stim, Parent, Population, Group) |>
 #'                        reframe(pairwise_test_cont(x = PercentCellNet,
 #'                                                   group = Visit,
 #'                                                   paired = TRUE,
@@ -474,8 +474,8 @@ pairwise_test_cont <- function(
 #' data(exampleData_BAMA)
 #'
 #' ## Group Comparison
-#'group_testing <- exampleData_BAMA %>%
-#'    group_by(antigen, visitno) %>%
+#'group_testing <- exampleData_BAMA |>
+#'    group_by(antigen, visitno) |>
 #'    group_modify(~ as.data.frame(
 #'        pairwise_test_bin(x = .$response, group = .$group,
 #'                method = 'barnard', alternative = 'less',
@@ -484,8 +484,8 @@ pairwise_test_cont <- function(
 #'
 #'
 #' ## Timepoint Comparison
-#'timepoint_testing <- exampleData_BAMA %>%
-#'    group_by(antigen, group) %>%
+#'timepoint_testing <- exampleData_BAMA |>
+#'    group_by(antigen, group) |>
 #'    group_modify(~ as.data.frame(
 #'        pairwise_test_bin(x = .$response, group = .$visitno, id = .$pubID,
 #'                method = 'mcnemar', num_needed_for_test = 3, digits = 1,
@@ -495,16 +495,16 @@ pairwise_test_cont <- function(
 #' data(exampleData_ICS)
 #'
 #' ## Group Comparison
-#'group_testing <- exampleData_ICS %>%
-#'    group_by(Stim, Parent, Population, Visit) %>%
+#'group_testing <- exampleData_ICS |>
+#'    group_by(Stim, Parent, Population, Visit) |>
 #'    group_modify(~ as.data.frame(
 #'        pairwise_test_bin(x = .$response, group = .$Group , alternative = 'greater',
 #'                method = 'barnard', num_needed_for_test = 3, digits = 1,
 #'                trailing_zeros = TRUE, sep_val = ' vs. ', verbose = TRUE)))
 #'
 #' ## Timepoint Comparison
-#'timepoint_testing <- exampleData_ICS %>%
-#'    group_by(Stim, Parent, Population, Group) %>%
+#'timepoint_testing <- exampleData_ICS |>
+#'    group_by(Stim, Parent, Population, Group) |>
 #'    group_modify(~ as.data.frame(
 #'        pairwise_test_bin(x = .$response, group = .$Visit, id = .$pubID,
 #'                method = 'mcnemar', num_needed_for_test = 3, digits = 1,
@@ -771,9 +771,9 @@ pairwise_test_bin <- function(x,
 #' data(exampleData_BAMA)
 #'
 #' ## Antigen Correlation
-#' exampleData_BAMA %>%
-#' filter(visitno != 0) %>%
-#' group_by(group, visitno) %>%
+#' exampleData_BAMA |>
+#' filter(visitno != 0) |>
+#' group_by(group, visitno) |>
 #'  summarize(
 #'    cor_test_pairs(x = magnitude, pair = antigen, id = pubID,
 #'    method = 'spearman', n_distinct_value = 3, digits = 1, verbose = TRUE),

--- a/R/pretty_output_functions.R
+++ b/R/pretty_output_functions.R
@@ -44,8 +44,8 @@
 #' library(tidyr)
 #' data(exampleData_BAMA)
 #'
-#' descriptive_stats_by_group <- exampleData_BAMA %>%
-#'   group_by(visitno,antigen) %>%
+#' descriptive_stats_by_group <- exampleData_BAMA |>
+#'   group_by(visitno,antigen) |>
 #'   reframe(
 #'     Group1 = unique(group[group == 1]), Group2 = unique(group[group == 2]),
 #'     Group1_n = length(magnitude[group == 1]), Group2_n = length(magnitude[group == 2]),
@@ -70,16 +70,16 @@
 #' # Same example wit tidyverse in single pipe
 #'
 #'
-#'exampleData_BAMA %>%
-#'  mutate(group = paste0("Group", group)) %>%
-#'  group_by(group, visitno, antigen) %>%
+#'exampleData_BAMA |>
+#'  mutate(group = paste0("Group", group)) |>
+#'  group_by(group, visitno, antigen) |>
 #'  reframe(N = n(), mean = mean(magnitude), sd = sd(magnitude),
 #'          median = median(magnitude), min = min(magnitude),
-#'          max = max(magnitude), q95_fun = quantile(magnitude, 0.95)) %>%
-#'  pivot_longer(-(group:antigen)) %>% # these three chains create a wide dataset
-#'  unite(temp, group, name) %>%
-#'  pivot_wider(names_from = temp, values_from = value) %>%
-#'  mutate(Group1 = "Group 1", Group2 = "Group 2") %>%
+#'          max = max(magnitude), q95_fun = quantile(magnitude, 0.95)) |>
+#'  pivot_longer(-(group:antigen)) |> # these three chains create a wide dataset
+#'  unite(temp, group, name) |>
+#'  pivot_wider(names_from = temp, values_from = value) |>
+#'  mutate(Group1 = "Group 1", Group2 = "Group 2") |>
 #'  paste_tbl_grp()
 #'
 #' @export
@@ -310,8 +310,8 @@ paste_tbl_grp <- function(
 #' stat_paste(c(rep(5,5),NA),c(1:5,NA),c(1,NA,2,NA,3,NA),bound_char = '[')
 #'
 #' library(dplyr)
-#' exampleData_BAMA %>%
-#' group_by(antigen, visitno, group) %>%
+#' exampleData_BAMA |>
+#' group_by(antigen, visitno, group) |>
 #' summarise(median_min_max = stat_paste(median(magnitude, na.rm = TRUE),
 #'                                         min(magnitude, na.rm = TRUE),
 #'                                         max(magnitude, na.rm = TRUE)),

--- a/R/reproducibility_tables.R
+++ b/R/reproducibility_tables.R
@@ -99,21 +99,21 @@ get_full_name <- function(id = NULL){
 #'
 #' # Simple HTML Display
 #' kableExtra::kable(my_session_info$platform_table, 'html',
-#'       caption = "Reproducibility Software Session Information") %>%
+#'       caption = "Reproducibility Software Session Information") |>
 #'       kableExtra::kable_styling()
 #'
 #' kableExtra::kable(my_session_info$packages_table, 'html',
-#'       caption = "Reproducibility Software Package Version Information") %>%
+#'       caption = "Reproducibility Software Package Version Information") |>
 #'       kableExtra::kable_styling()
 #'
 #'
 #' # Latex Display
 #' kableExtra::kable(my_session_info$platform_table, 'latex', booktabs = TRUE,
-#'       linesep = '', caption = "Reproducibility Software Session Information") %>%
+#'       linesep = '', caption = "Reproducibility Software Session Information") |>
 #'       kableExtra::kable_styling(font_size = 7)
 #'
 #' kableExtra::kable(my_session_info$packages_table, 'latex', booktabs = TRUE,
-#'       linesep = '', caption = "Reproducibility Software Package Version Information") %>%
+#'       linesep = '', caption = "Reproducibility Software Package Version Information") |>
 #'       kableExtra::kable_styling(font_size = 7)
 #'
 #' @export

--- a/R/step_curves.R
+++ b/R/step_curves.R
@@ -34,24 +34,24 @@
 #'                  event = c(1,1,0,1,1,0,0,1,1,1),
 #'                  ptid = c(1,1,2,2,3,3,3,3,3,3))
 #' plot_data <-
-#'  dat %>%
-#'   dplyr::group_by(ptid) %>%
+#'  dat |>
+#'   dplyr::group_by(ptid) |>
 #'   dplyr::group_modify(~ create_step_curve(x = .x$x, event = .x$event))
 #'
 #' ggplot2::ggplot(data = plot_data,
 #'                 ggplot2::aes(x = time, y = surv, color = factor(ptid))) +
 #'  ggplot2::geom_step(linetype = "dashed", direction = 'hv', lwd = .35) +
-#'  ggplot2::geom_point(data = plot_data %>% filter(n.censor == 1),
+#'  ggplot2::geom_point(data = plot_data |> filter(n.censor == 1),
 #'                      shape = 3, size = 6, show.legend = FALSE)
 #'
 #' #mAB example for reverse curves
 #' data(CAVD812_mAB)
 #'
 #' plot_data <-
-#' CAVD812_mAB %>%
-#'   filter(virus != 'SVA-MLV') %>%
-#'   tidyr::pivot_longer(cols = c(ic50, ic80)) %>%
-#'   dplyr::group_by(name, product) %>%
+#' CAVD812_mAB |>
+#'   filter(virus != 'SVA-MLV') |>
+#'   tidyr::pivot_longer(cols = c(ic50, ic80)) |>
+#'   dplyr::group_by(name, product) |>
 #'   dplyr::group_modify(~ create_step_curve(x = pmin(.x$value, 100),
 #'                                           event = as.numeric(.x$value < 50),
 #'                                           flip_surv = TRUE,
@@ -160,8 +160,8 @@ create_step_curve <- function(x,
 #'                  response = c(1,1,0,1,1,0,0,1,1,1),
 #'                  ptid = c(1,1,2,2,3,3,3,3,3,3))
 #' ind_results <-
-#'  dat %>%
-#'   dplyr::group_by(ptid) %>%
+#'  dat |>
+#'   dplyr::group_by(ptid) |>
 #'   dplyr::group_modify(~ mb_results(magnitude = .x$magnitude, response = .x$response))
 #'
 #' overall_results <-
@@ -179,17 +179,17 @@ create_step_curve <- function(x,
 #' data(exampleData_BAMA)
 #'
 #' data_here <-
-#'  exampleData_BAMA %>%
+#'  exampleData_BAMA |>
 #'  filter(visitno == 2)
 #'
 #' group_results <-
-#'   data_here %>%
-#'   dplyr::group_by(group) %>%
+#'   data_here |>
+#'   dplyr::group_by(group) |>
 #'   dplyr::group_modify(~ mb_results(magnitude = .x$magnitude , response = .x$response))
 #'
 #' ind_results <-
-#'   data_here %>%
-#'   dplyr::group_by(group, pubID) %>%
+#'   data_here |>
+#'   dplyr::group_by(group, pubID) |>
 #'   dplyr::group_modify(~ mb_results(magnitude = .x$magnitude , response = .x$response))
 #'
 #' ggplot2::ggplot(data = group_results,

--- a/data-raw/cds_datasets.R
+++ b/data-raw/cds_datasets.R
@@ -5,13 +5,13 @@ library(DataSpaceR)
 con <- connectDS()
 
 cvd812 <- con$getStudy('cvd812')
-CAVD812_mAB <- cvd812$getDataset("NAB Ig") %>%
+CAVD812_mAB <- cvd812$getDataset("NAB Ig") |>
   distinct(
     product = mab_name_source,
     virus = cds_virus_name,
     ic50 = titer_curve_ic50,
     ic80 = titer_curve_ic80
-  ) %>% as.data.frame()
+  ) |> as.data.frame()
 
 usethis::use_data(CAVD812_mAB, overwrite = TRUE)
 

--- a/data-raw/fas_example_data.R
+++ b/data-raw/fas_example_data.R
@@ -21,11 +21,11 @@ fas <- fread('data-raw/flow_and_sequences.csv.gz')
 # ubs <- fread('unblinded_sequences.csv')
 
 # check that we have one row per ppt + visit
-fas %>%
-  group_by(PubID, Visit) %>%
-  summarize(n = n()) %>%
-  pull(n) %>%
-  unique %>%
+fas |>
+  group_by(PubID, Visit) |>
+  summarize(n = n()) |>
+  pull(n) |>
+  unique |>
   expect_equal(1)
 
 non_numeric <- grep('^Number |^Percent ', names(fas), value = TRUE, invert = TRUE)
@@ -125,7 +125,7 @@ one_step_impute <- function(
 
 # first: filter down to particular endpoints/variables of interest and pivot
 # data to long, resulting in a bare-bones long-format version of the dataset
-df_filtered_long <- fas %>%
+df_filtered_long <- fas |>
   # discard unneeded numeric (Percent* / Number*) columns
   select(
     all_of(
@@ -134,11 +134,11 @@ df_filtered_long <- fas %>%
         c(non_numeric, keep_numeric)
       )
     )
-  ) %>%
-  select(! all_of(drop_cols)) %>%
+  ) |>
+  select(! all_of(drop_cols)) |>
   # subset on and then remove a column name that is nearly reused later
-  filter(BCell_Population == "/Lymphocytes/Singlets/Live|Dump-/CD19+CD20+") %>%
-  select(-BCell_Population) %>%
+  filter(BCell_Population == "/Lymphocytes/Singlets/Live|Dump-/CD19+CD20+") |>
+  select(-BCell_Population) |>
   # from kellie's processing, lightly edited
   pivot_longer(
     c(
@@ -147,52 +147,52 @@ df_filtered_long <- fas %>%
     ),
     names_to = 'endpoint',
     values_to = 'endpoint_value'
-  ) %>%
+  ) |>
   mutate(endpoint_value_type = case_when(
     grepl('^Percent', endpoint) ~ 'percent',
     grepl('^Number', endpoint) ~ 'count',
-  )) %>%
+  )) |>
   # impute certain endpoints, using upper estimates for pre-vaccination time
   # points and lower estimates (zero) for post-vaccination time points
-  group_by(PubID, weeks_post) %>%
+  group_by(PubID, weeks_post) |>
   mutate(endpoint_value_imputed = case_when(
     # sequencing-only percentage endpoints
     is.na(endpoint_value) & (weeks_post == -4) & (endpoint == "Percent of epitope-specific (KO-GT8++) sequenced IgG BCRs that are VRC01-class") ~ 100,
     is.na(endpoint_value) & (weeks_post > 0) & (endpoint == "Percent of epitope-specific (KO-GT8++) sequenced IgG BCRs that are VRC01-class") ~ 0,
     .default = endpoint_value
-  )) %>%
+  )) |>
   # flow and sequencing percentage endpoints
   # impute "Percent of B cells detected as VRC01-class"
   group_modify(
     one_step_impute,
     Y = "Number of B cells",
     d = "Percent of B cells detected as VRC01-class"
-  ) %>%
+  ) |>
   # impute "Percent of IgG+ B cells detected as VRC01-class"
   group_modify(
     one_step_impute,
     Y = "Number of IgD-IgG+ B cells",
     d = "Percent of IgG+ B cells detected as VRC01-class"
-  ) %>%
+  ) |>
   # impute "Percent of GT8++ IgG+ B cells detected as VRC01-class"
   group_modify(
     one_step_impute,
     Y = "Number of IgD-IgG+ B cells that are GT8++ (without regard to KO binding status)",
     d = "Percent of GT8++ IgG+ B cells detected as VRC01-class"
-  ) %>%
+  ) |>
   ungroup()
 
 # next: add/format supplemental columns bcell_population, percent_denominator,
 # igx_type, antigen_specificity, epitope_specificity, bnab_class
 # as well as sample metadata columns related to participant, visit, and assay
-df <- df_filtered_long %>%
+df <- df_filtered_long |>
   mutate(
     bcell_population = endpoint,
     bcell_population = sub('Number of ', '', bcell_population),
     # for a typo in original dataset
     bcell_population = sub('Number ', '', bcell_population),
     bcell_population = sub('Percent of .+ (that are|detected as) ', '', bcell_population)
-  ) %>%
+  ) |>
   mutate(
     percent_denominator = if_else(
       endpoint_value_type == 'percent',
@@ -250,7 +250,7 @@ df <- df_filtered_long %>%
     sample_type = 'PBMC',
     source_file = 'https://github.com/SchiefLab/G001/raw/main/data/figures/flow_summary/flow_and_sequences.csv.gz',
     PubID = sub('^PubID_', '', PubID)
-  ) %>%
+  ) |>
   mutate(
     bcell_population = if_else(
       endpoint_value_type == "percent" & source_assay == "flow",
@@ -258,7 +258,7 @@ df <- df_filtered_long %>%
       bcell_population
     ),
     bcell_population = sub("(GT8[+][+]KO-) GT8[+][+]", "\\1", bcell_population)
-  ) %>%
+  ) |>
   # Select/rename/reorder columns
   select(
     pubid = PubID,
@@ -283,14 +283,14 @@ df <- df_filtered_long %>%
     epitope_specificity,
     bnab_class,
     source_file
-  ) %>%
+  ) |>
   arrange(pubid, visit, source_assay, endpoint_value_type, endpoint)
 
 # # to review the imputed values
-# df %>%
-#   filter(is.na(endpoint_value)) %>%
-#   select(pubid, visit, endpoint, endpoint_value, endpoint_value_imputed) %>%
-#   arrange(endpoint, visit) %>%
+# df |>
+#   filter(is.na(endpoint_value)) |>
+#   select(pubid, visit, endpoint, endpoint_value, endpoint_value_imputed) |>
+#   arrange(endpoint, visit) |>
 #   View()
 
 G001_Bcell_flow_seq_PBMC <- df

--- a/man/collapse_group_row.Rd
+++ b/man/collapse_group_row.Rd
@@ -30,7 +30,7 @@ sample_df <- data.frame(
 
 library(dplyr)
 options(knitr.kable.NA = '')
-collapse_group_row(sample_df, x, y, z) \%>\%
- kableExtra::kable() \%>\%
+collapse_group_row(sample_df, x, y, z) |>
+ kableExtra::kable() |>
  kableExtra::kable_styling()
 }

--- a/man/cor_test_pairs.Rd
+++ b/man/cor_test_pairs.Rd
@@ -107,9 +107,9 @@ library(dplyr)
 data(exampleData_BAMA)
 
 ## Antigen Correlation
-exampleData_BAMA \%>\%
-filter(visitno != 0) \%>\%
-group_by(group, visitno) \%>\%
+exampleData_BAMA |>
+filter(visitno != 0) |>
+group_by(group, visitno) |>
  summarize(
    cor_test_pairs(x = magnitude, pair = antigen, id = pubID,
    method = 'spearman', n_distinct_value = 3, digits = 1, verbose = TRUE),

--- a/man/create_step_curve.Rd
+++ b/man/create_step_curve.Rd
@@ -49,24 +49,24 @@ dat = data.frame(x = c(1:10),
                  event = c(1,1,0,1,1,0,0,1,1,1),
                  ptid = c(1,1,2,2,3,3,3,3,3,3))
 plot_data <-
- dat \%>\%
-  dplyr::group_by(ptid) \%>\%
+ dat |>
+  dplyr::group_by(ptid) |>
   dplyr::group_modify(~ create_step_curve(x = .x$x, event = .x$event))
 
 ggplot2::ggplot(data = plot_data,
                 ggplot2::aes(x = time, y = surv, color = factor(ptid))) +
  ggplot2::geom_step(linetype = "dashed", direction = 'hv', lwd = .35) +
- ggplot2::geom_point(data = plot_data \%>\% filter(n.censor == 1),
+ ggplot2::geom_point(data = plot_data |> filter(n.censor == 1),
                      shape = 3, size = 6, show.legend = FALSE)
 
 #mAB example for reverse curves
 data(CAVD812_mAB)
 
 plot_data <-
-CAVD812_mAB \%>\%
-  filter(virus != 'SVA-MLV') \%>\%
-  tidyr::pivot_longer(cols = c(ic50, ic80)) \%>\%
-  dplyr::group_by(name, product) \%>\%
+CAVD812_mAB |>
+  filter(virus != 'SVA-MLV') |>
+  tidyr::pivot_longer(cols = c(ic50, ic80)) |>
+  dplyr::group_by(name, product) |>
   dplyr::group_modify(~ create_step_curve(x = pmin(.x$value, 100),
                                           event = as.numeric(.x$value < 50),
                                           flip_surv = TRUE,

--- a/man/get_full_name.Rd
+++ b/man/get_full_name.Rd
@@ -7,7 +7,8 @@
 get_full_name(id = NULL)
 }
 \arguments{
-\item{id}{ID to look full name up. If null (default) looks up ID of current user}
+\item{id}{ID to look full name up. If null (default) looks up ID of current
+user}
 }
 \value{
 First and Last name associated with ID
@@ -16,7 +17,10 @@ First and Last name associated with ID
 For a given ID looks up user name
 }
 \details{
-If \code{id} null, uses system "USERNAME" variable for Windows and "USER" variable for Linux and MACs. Full Name is found in Windows via the \code{net} command, and via ldap search in Linux and MACs. The ldap search will only work on SCHARPs network at Fred Hutching Cancer Research Center.
+If \code{id} null, uses system "USERNAME" variable for Windows and "USER"
+variable for Linux and MACs. Full Name is found in Windows via the \code{net}
+command, and via ldap search in Linux and MACs. The ldap search will only
+work on SCHARPs network at Fred Hutching Cancer Research Center.
 }
 \examples{
 

--- a/man/get_session_info.Rd
+++ b/man/get_session_info.Rd
@@ -10,17 +10,23 @@ get_session_info(libpath = FALSE)
 \item{libpath}{Show R package library path column in packages table}
 }
 \value{
-list of length two, containing dataframe of Software Session Information and dataframe of Software Package Version Information
+list of length two, containing dataframe of Software Session
+Information and dataframe of Software Package Version Information
 }
 \description{
-Creating tables used at the end of reports, for reproducibility. Most of the information is based off of sessioninfo::session_info()
+Creating tables used at the end of reports, for reproducibility. Most of the
+information is based off of sessioninfo::session_info()
 }
 \details{
 Both tables usually printing with \code{kable()} at the end of a report.
 
-If any loaded packages have a \code{DataVersion} field then the Software Package Version Information will contain a \code{data.version} column.
+If any loaded packages have a \code{DataVersion} field then the Software
+Package Version Information will contain a \code{data.version} column.
 
-Full Name is found in Windows via the \code{net} command, and via ldap search in Linux and MACs. The ldap search will only work on SCHARPs network at Fred Hutching Cancer Research Center. If there is an error attempting to get the Full Name, the system usernam will be displayed instead.
+Full Name is found in Windows via the \code{net} command, and via ldap search
+in Linux and MACs. The ldap search will only work on SCHARPs network at Fred
+Hutching Cancer Research Center. If there is an error attempting to get the
+Full Name, the system usernam will be displayed instead.
 }
 \examples{
 

--- a/man/get_session_info.Rd
+++ b/man/get_session_info.Rd
@@ -36,21 +36,21 @@ library(dplyr)
 
 # Simple HTML Display
 kableExtra::kable(my_session_info$platform_table, 'html',
-      caption = "Reproducibility Software Session Information") \%>\%
+      caption = "Reproducibility Software Session Information") |>
       kableExtra::kable_styling()
 
 kableExtra::kable(my_session_info$packages_table, 'html',
-      caption = "Reproducibility Software Package Version Information") \%>\%
+      caption = "Reproducibility Software Package Version Information") |>
       kableExtra::kable_styling()
 
 
 # Latex Display
 kableExtra::kable(my_session_info$platform_table, 'latex', booktabs = TRUE,
-      linesep = '', caption = "Reproducibility Software Session Information") \%>\%
+      linesep = '', caption = "Reproducibility Software Session Information") |>
       kableExtra::kable_styling(font_size = 7)
 
 kableExtra::kable(my_session_info$packages_table, 'latex', booktabs = TRUE,
-      linesep = '', caption = "Reproducibility Software Package Version Information") \%>\%
+      linesep = '', caption = "Reproducibility Software Package Version Information") |>
       kableExtra::kable_styling(font_size = 7)
 
 }

--- a/man/mb_results.Rd
+++ b/man/mb_results.Rd
@@ -69,8 +69,8 @@ dat = data.frame(magnitude = c(500,800,20,150,30000,10,1,2000,10000,900),
                  response = c(1,1,0,1,1,0,0,1,1,1),
                  ptid = c(1,1,2,2,3,3,3,3,3,3))
 ind_results <-
- dat \%>\%
-  dplyr::group_by(ptid) \%>\%
+ dat |>
+  dplyr::group_by(ptid) |>
   dplyr::group_modify(~ mb_results(magnitude = .x$magnitude, response = .x$response))
 
 overall_results <-
@@ -88,17 +88,17 @@ ggplot2::ggplot(data = overall_results, ggplot2::aes(x = magnitude, y = breadth)
 data(exampleData_BAMA)
 
 data_here <-
- exampleData_BAMA \%>\%
+ exampleData_BAMA |>
  filter(visitno == 2)
 
 group_results <-
-  data_here \%>\%
-  dplyr::group_by(group) \%>\%
+  data_here |>
+  dplyr::group_by(group) |>
   dplyr::group_modify(~ mb_results(magnitude = .x$magnitude , response = .x$response))
 
 ind_results <-
-  data_here \%>\%
-  dplyr::group_by(group, pubID) \%>\%
+  data_here |>
+  dplyr::group_by(group, pubID) |>
   dplyr::group_modify(~ mb_results(magnitude = .x$magnitude , response = .x$response))
 
 ggplot2::ggplot(data = group_results,

--- a/man/pairwise_test_bin.Rd
+++ b/man/pairwise_test_bin.Rd
@@ -118,8 +118,8 @@ library(dplyr)
 data(exampleData_BAMA)
 
 ## Group Comparison
-group_testing <- exampleData_BAMA \%>\%
-   group_by(antigen, visitno) \%>\%
+group_testing <- exampleData_BAMA |>
+   group_by(antigen, visitno) |>
    group_modify(~ as.data.frame(
        pairwise_test_bin(x = .$response, group = .$group,
                method = 'barnard', alternative = 'less',
@@ -128,8 +128,8 @@ group_testing <- exampleData_BAMA \%>\%
 
 
 ## Timepoint Comparison
-timepoint_testing <- exampleData_BAMA \%>\%
-   group_by(antigen, group) \%>\%
+timepoint_testing <- exampleData_BAMA |>
+   group_by(antigen, group) |>
    group_modify(~ as.data.frame(
        pairwise_test_bin(x = .$response, group = .$visitno, id = .$pubID,
                method = 'mcnemar', num_needed_for_test = 3, digits = 1,
@@ -139,16 +139,16 @@ timepoint_testing <- exampleData_BAMA \%>\%
 data(exampleData_ICS)
 
 ## Group Comparison
-group_testing <- exampleData_ICS \%>\%
-   group_by(Stim, Parent, Population, Visit) \%>\%
+group_testing <- exampleData_ICS |>
+   group_by(Stim, Parent, Population, Visit) |>
    group_modify(~ as.data.frame(
        pairwise_test_bin(x = .$response, group = .$Group , alternative = 'greater',
                method = 'barnard', num_needed_for_test = 3, digits = 1,
                trailing_zeros = TRUE, sep_val = ' vs. ', verbose = TRUE)))
 
 ## Timepoint Comparison
-timepoint_testing <- exampleData_ICS \%>\%
-   group_by(Stim, Parent, Population, Group) \%>\%
+timepoint_testing <- exampleData_ICS |>
+   group_by(Stim, Parent, Population, Group) |>
    group_modify(~ as.data.frame(
        pairwise_test_bin(x = .$response, group = .$Visit, id = .$pubID,
                method = 'mcnemar', num_needed_for_test = 3, digits = 1,

--- a/man/pairwise_test_cont.Rd
+++ b/man/pairwise_test_cont.Rd
@@ -124,8 +124,8 @@ library(dplyr)
 data(exampleData_BAMA)
 
 ## Group Comparison
-group_testing_tibble <- exampleData_BAMA \%>\%
-   group_by(antigen, visitno) \%>\%
+group_testing_tibble <- exampleData_BAMA |>
+   group_by(antigen, visitno) |>
    reframe(pairwise_test_cont(x = magnitude,
                               group = group,
                               paired = FALSE,
@@ -138,8 +138,8 @@ group_testing_tibble <- exampleData_BAMA \%>\%
 
 
 ## Timepoint Comparison
-timepoint_testing_dt <- exampleData_BAMA \%>\%
-                       group_by(antigen, group) \%>\%
+timepoint_testing_dt <- exampleData_BAMA |>
+                       group_by(antigen, group) |>
                        reframe(pairwise_test_cont(x = magnitude,
                                                   group = visitno,
                                                   paired = TRUE,
@@ -159,8 +159,8 @@ data(exampleData_ICS)
 
 ## Group Comparison
 # using dplyr
-exampleData_ICS \%>\%
-group_by(Stim, Parent, Population, Visit) \%>\%
+exampleData_ICS |>
+group_by(Stim, Parent, Population, Visit) |>
 reframe(pairwise_test_cont(x = PercentCellNet,
                           group = Group,
                           paired = FALSE,
@@ -174,8 +174,8 @@ reframe(pairwise_test_cont(x = PercentCellNet,
                           verbose = TRUE))
 
 # Timepoint Comparison
-timepoint_testing_dt <- exampleData_ICS \%>\%
-                       group_by(Stim, Parent, Population, Group) \%>\%
+timepoint_testing_dt <- exampleData_ICS |>
+                       group_by(Stim, Parent, Population, Group) |>
                        reframe(pairwise_test_cont(x = PercentCellNet,
                                                   group = Visit,
                                                   paired = TRUE,

--- a/man/paste_tbl_grp.Rd
+++ b/man/paste_tbl_grp.Rd
@@ -74,8 +74,8 @@ library(dplyr)
 library(tidyr)
 data(exampleData_BAMA)
 
-descriptive_stats_by_group <- exampleData_BAMA \%>\%
-  group_by(visitno,antigen) \%>\%
+descriptive_stats_by_group <- exampleData_BAMA |>
+  group_by(visitno,antigen) |>
   reframe(
     Group1 = unique(group[group == 1]), Group2 = unique(group[group == 2]),
     Group1_n = length(magnitude[group == 1]), Group2_n = length(magnitude[group == 2]),
@@ -100,16 +100,16 @@ paste_tbl_grp(data = descriptive_stats_by_group, vars_to_paste = 'all', first_na
 # Same example wit tidyverse in single pipe
 
 
-exampleData_BAMA \%>\%
- mutate(group = paste0("Group", group)) \%>\%
- group_by(group, visitno, antigen) \%>\%
+exampleData_BAMA |>
+ mutate(group = paste0("Group", group)) |>
+ group_by(group, visitno, antigen) |>
  reframe(N = n(), mean = mean(magnitude), sd = sd(magnitude),
          median = median(magnitude), min = min(magnitude),
-         max = max(magnitude), q95_fun = quantile(magnitude, 0.95)) \%>\%
- pivot_longer(-(group:antigen)) \%>\% # these three chains create a wide dataset
- unite(temp, group, name) \%>\%
- pivot_wider(names_from = temp, values_from = value) \%>\%
- mutate(Group1 = "Group 1", Group2 = "Group 2") \%>\%
+         max = max(magnitude), q95_fun = quantile(magnitude, 0.95)) |>
+ pivot_longer(-(group:antigen)) |> # these three chains create a wide dataset
+ unite(temp, group, name) |>
+ pivot_wider(names_from = temp, values_from = value) |>
+ mutate(Group1 = "Group 1", Group2 = "Group 2") |>
  paste_tbl_grp()
 
 }

--- a/man/stat_paste.Rd
+++ b/man/stat_paste.Rd
@@ -66,8 +66,8 @@ stat_paste(5.109, "p < 0.001", digits = 3)
 stat_paste(c(rep(5,5),NA),c(1:5,NA),c(1,NA,2,NA,3,NA),bound_char = '[')
 
 library(dplyr)
-exampleData_BAMA \%>\%
-group_by(antigen, visitno, group) \%>\%
+exampleData_BAMA |>
+group_by(antigen, visitno, group) |>
 summarise(median_min_max = stat_paste(median(magnitude, na.rm = TRUE),
                                         min(magnitude, na.rm = TRUE),
                                         max(magnitude, na.rm = TRUE)),

--- a/tests/testthat/test-step_curves.R
+++ b/tests/testthat/test-step_curves.R
@@ -69,9 +69,9 @@ test_that("create_step_curve testing", {
     ))
 
   expect_identical(
-    object = dat %>%
-      dplyr::group_by(ptid) %>%
-      dplyr::group_modify(~ create_step_curve(x = .x$x, event = .x$event)) %>%
+    object = dat |>
+      dplyr::group_by(ptid) |>
+      dplyr::group_modify(~ create_step_curve(x = .x$x, event = .x$event)) |>
       dplyr::ungroup(),
     expected = expected_output
   )

--- a/tests/testthat/test_pairwise_comparisons.R
+++ b/tests/testthat/test_pairwise_comparisons.R
@@ -13,9 +13,9 @@ test_that("pairwise_comparisons_bin testing two groups", {
 
   test_data <- data.frame(x, group)
 
-  testing_stats <- test_data %>%
-    filter(!is.na(x)) %>%
-    group_by(group) %>%
+  testing_stats <- test_data |>
+    filter(!is.na(x)) |>
+    group_by(group) |>
     summarise(n = n(),
               mean = mean(x, na.rm = TRUE),
               sd = sd(x, na.rm = TRUE),
@@ -23,9 +23,9 @@ test_that("pairwise_comparisons_bin testing two groups", {
               min = min(x, na.rm = TRUE),
               max = max(x, na.rm = TRUE),
               IQR = IQR(x, na.rm = TRUE),
-              .groups = "keep") %>%
+              .groups = "keep") |>
     pivot_wider(names_from = group,
-                values_from = c(n, mean, sd, median, min, max, IQR)) %>%
+                values_from = c(n, mean, sd, median, min, max, IQR)) |>
     mutate(Group1 = "a", Group2 = "b", .before = "n_a")
 
   colnames(testing_stats)[3:16] <- c("Group1_n", "Group2_n", "Group1_mean",
@@ -52,7 +52,7 @@ test_that("pairwise_comparisons_bin testing two groups", {
                                                              (testing_stats$Group2_min >  testing_stats$Group1_max),
                                                            TRUE, FALSE))
 
-  expect_equal(object = test_data %>% pairwise_test_cont(x = x,
+  expect_equal(object = test_data |> pairwise_test_cont(x = x,
                                            group = group, paired = FALSE,
                                            method = 'wilcox',
                                            alternative = 'two.sided',
@@ -78,7 +78,7 @@ test_that("pairwise_comparisons_bin testing two groups", {
                                                              (testing_stats$Group2_min >  testing_stats$Group1_max),
                                                            TRUE, FALSE))
 
-  expect_equal(object = test_data %>% pairwise_test_cont(x = x,
+  expect_equal(object = test_data |> pairwise_test_cont(x = x,
                                            group = group,
                                            paired = FALSE,
                                            method = 'wilcox',
@@ -106,7 +106,7 @@ test_that("pairwise_comparisons_bin testing two groups", {
                                 PerfectSeparation = ifelse((testing_stats$Group1_min >  testing_stats$Group2_max) |
                                                              (testing_stats$Group2_min >  testing_stats$Group1_max),
                                                            TRUE, FALSE))
-  expect_equal(object = test_data %>% pairwise_test_cont(x = x,
+  expect_equal(object = test_data |> pairwise_test_cont(x = x,
                                            group = group,
                                            paired = FALSE,
                                            method = 'wilcox',
@@ -132,7 +132,7 @@ test_that("pairwise_comparisons_bin testing two groups", {
                                 PerfectSeparation = ifelse((testing_stats$Group1_min >  testing_stats$Group2_max) |
                                                              (testing_stats$Group2_min >  testing_stats$Group1_max),
                                                            TRUE, FALSE))
-  expect_equal(object = test_data %>% pairwise_test_cont(x = x,
+  expect_equal(object = test_data |> pairwise_test_cont(x = x,
                                            group = group,
                                            paired = FALSE,
                                            method = 'wilcox',
@@ -160,7 +160,7 @@ test_that("pairwise_comparisons_bin testing two groups", {
                                 PerfectSeparation = ifelse((testing_stats$Group1_min >  testing_stats$Group2_max) |
                                                              (testing_stats$Group2_min >  testing_stats$Group1_max),
                                                            TRUE, FALSE))
-  expect_equal(object = test_data %>% pairwise_test_cont(x = x, group = group,
+  expect_equal(object = test_data |> pairwise_test_cont(x = x, group = group,
                                            paired = FALSE, method = 'wilcox',
                                            alternative = 'less',
                                            num_needed_for_test = 3, digits = 3,
@@ -185,7 +185,7 @@ test_that("pairwise_comparisons_bin testing two groups", {
                                                              (testing_stats$Group2_min >  testing_stats$Group1_max),
                                                            TRUE, FALSE))
 
-  expect_equal(object = test_data %>% pairwise_test_cont(x = x, group = group, paired = FALSE,
+  expect_equal(object = test_data |> pairwise_test_cont(x = x, group = group, paired = FALSE,
                                            method = 't.test', alternative = 'two.sided',
                                            num_needed_for_test = 3, digits = 3,
                                            trailing_zeros = TRUE, sep_val = ' vs. ', verbose = FALSE),
@@ -203,7 +203,7 @@ test_that("pairwise_comparisons_bin testing two groups", {
                                 PerfectSeparation = ifelse((testing_stats$Group1_min >  testing_stats$Group2_max) |
                                                              (testing_stats$Group2_min >  testing_stats$Group1_max),
                                                            TRUE, FALSE))
-  expect_equal(object = test_data %>% pairwise_test_cont(x = x, group = group,
+  expect_equal(object = test_data |> pairwise_test_cont(x = x, group = group,
                                            paired = FALSE, method = 'wilcox',
                                            alternative = 'two.sided', num_needed_for_test = 100,
                                            digits = 3, trailing_zeros = TRUE,
@@ -216,10 +216,10 @@ test_that("pairwise_comparisons_bin testing two groups", {
 
   test_data_log <- data.frame(x_high, group)
 
-  testing_stats_log <- test_data_log %>%
-    filter(!is.na(x)) %>%
-    mutate(x = log10(x_high)) %>%
-    group_by(group) %>%
+  testing_stats_log <- test_data_log |>
+    filter(!is.na(x)) |>
+    mutate(x = log10(x_high)) |>
+    group_by(group) |>
     summarise(n = n(),
               mean = mean(x, na.rm = TRUE),
               median = median(x, na.rm = TRUE),
@@ -228,9 +228,9 @@ test_that("pairwise_comparisons_bin testing two groups", {
               IQR = IQR(x, na.rm = TRUE),
               logmean = mean(x, na.rm = TRUE),
               logsd = sd(x, na.rm = TRUE),
-              .groups = "keep") %>%
+              .groups = "keep") |>
     pivot_wider(names_from = group,
-                values_from = c(n, mean, median, min, max, IQR, logmean, logsd)) %>%
+                values_from = c(n, mean, median, min, max, IQR, logmean, logsd)) |>
     mutate(across(mean_a:IQR_b, .fns = ~10^.x),
            Group1 = "a", Group2 = "b",
            Group1log = "a", Group2log = "b", .before = "n_a")
@@ -284,10 +284,10 @@ test_that("pairwise_comparisons_bin testing two groups", {
 
   # Paired data
 
-  test_ids <- test_data %>% mutate(id = rep(1:26, 2)) %>% filter(!is.na(x))
+  test_ids <- test_data |> mutate(id = rep(1:26, 2)) |> filter(!is.na(x))
   dup_id <- test_ids[duplicated(test_ids$id),]
-  testing_stats_paired <- test_ids %>% filter(id %in% dup_id$id) %>%
-    group_by(group) %>%
+  testing_stats_paired <- test_ids |> filter(id %in% dup_id$id) |>
+    group_by(group) |>
     summarise(n = n(),
               mean = mean(x, na.rm = TRUE),
               sd = sd(x, na.rm = TRUE),
@@ -295,9 +295,9 @@ test_that("pairwise_comparisons_bin testing two groups", {
               min = min(x, na.rm = TRUE),
               max = max(x, na.rm = TRUE),
               IQR = IQR(x, na.rm = TRUE),
-              .groups = "keep") %>%
+              .groups = "keep") |>
     pivot_wider(names_from = group,
-                values_from = c(n, mean, sd, median, min, max, IQR)) %>%
+                values_from = c(n, mean, sd, median, min, max, IQR)) |>
     mutate(Group1 = "a", Group2 = "b", .before = "n_a")
 
   colnames(testing_stats_paired)[3:16] <- c("Group1_n", "Group2_n", "Group1_mean",
@@ -370,7 +370,7 @@ test_that("pairwise_comparisons testing multiple groups", {
     test_data <- data.frame(x = x[!is.na(x)],
                             group = group[!is.na(x)])
 
-    testing_stats <- test_data %>%
+    testing_stats <- test_data |>
       summarise(
         Group1 = unique(group[group == Group1]), Group2 = unique(group[group == Group2]),
         Group1_n = length(x[group == Group1]), Group2_n = length(x[group == Group2]),
@@ -417,13 +417,13 @@ test_that("pairwise_comparisons testing multiple groups", {
     }
   }
 
-  testing_results <- testData_BAMA %>%
-    group_by(antigen, visit) %>%
-    group_modify(~test_all_comp(x = .x$magnitude, group = .x$group) %>%
-                   as.data.frame)
+  testing_results <- testData_BAMA |>
+    group_by(antigen, visit) |>
+    group_modify(~test_all_comp(x = .x$magnitude, group = .x$group) |>
+                   as.data.frame())
 
-  group_testing_dt <- testData_BAMA %>%
-    group_by(antigen, visit) %>%
+  group_testing_dt <- testData_BAMA |>
+    group_by(antigen, visit) |>
     group_modify(~pairwise_test_cont(x = .x$magnitude,
                                      group = .x$group,
                                      paired = FALSE,
@@ -433,8 +433,8 @@ test_that("pairwise_comparisons testing multiple groups", {
                                      digits = 3,
                                      trailing_zeros = TRUE,
                                      sep_val = ' vs. ',
-                                     verbose = FALSE) %>%
-                   as.data.frame)
+                                     verbose = FALSE) |>
+                   as.data.frame())
 
   expect_equal(object = group_testing_dt,
                expected = testing_results)
@@ -445,11 +445,11 @@ test_that("Test example with fixed result", {
 
   data(exampleData_BAMA)
   source("fixed_data.R")
-  fixed_bama_group_testing_dt <- as_tibble(fixed_bama_group_testing_dt) %>%
+  fixed_bama_group_testing_dt <- as_tibble(fixed_bama_group_testing_dt) |>
     arrange(antigen)
 
-  group_testing_dt <- exampleData_BAMA %>%
-    group_by(antigen, visitno) %>%
+  group_testing_dt <- exampleData_BAMA |>
+    group_by(antigen, visitno) |>
     summarise(pairwise_test_cont(x = magnitude,
                                  group = group,
                                  paired = FALSE,
@@ -461,7 +461,7 @@ test_that("Test example with fixed result", {
                                  trailing_zeros = TRUE,
                                  sep_val = ' vs. ',
                                  verbose = TRUE),
-              .groups = "drop_last") %>%
+              .groups = "drop_last") |>
     ungroup()
 
   expect_equal(object = group_testing_dt,
@@ -472,7 +472,7 @@ test_that("Test example with fixed result", {
 test_that("Paired results with test data", {
   library(dplyr)
 
-  paired_example <- exampleData_BAMA %>%
+  paired_example <- exampleData_BAMA |>
     filter(visitno != 0, antigen == "B.63521_D11gp120/293F")
   paired_example_subset1 <- subset(paired_example,  visitno == 1, select = -response)
   paired_example_subset2 <- subset(paired_example,  visitno == 2, select = -response)
@@ -499,15 +499,15 @@ test_that("Paired results with test data", {
   }
   paired_tests <- do.call(rbind, paired_tests_ls)
 
-  group_testing_tibble <- paired_example %>%
-     group_by(group) %>%
+  group_testing_tibble <- paired_example |>
+     group_by(group) |>
      summarise(pairwise_test_cont(x = magnitude, group = visitno,
                            paired = TRUE,
                            id = pubID,
                            digits = 3,
                            num_needed_for_test = 2,
                            verbose = TRUE),
-               .groups = "keep") %>%
+               .groups = "keep") |>
     left_join(paired_tests, by = "group")
 
   expect_equal(group_testing_tibble$SampleSizes,
@@ -515,8 +515,8 @@ test_that("Paired results with test data", {
   expect_equal(group_testing_tibble$MagnitudeTest,
                group_testing_tibble$test)
 
-  group_testing_tibble_less <- paired_example %>%
-     group_by(group) %>%
+  group_testing_tibble_less <- paired_example |>
+     group_by(group) |>
      summarise(pairwise_test_cont(x = magnitude, group = visitno,
                            paired = TRUE,
                            id = pubID,
@@ -525,7 +525,7 @@ test_that("Paired results with test data", {
                            sorted_group = c(1, 2),
                            num_needed_for_test = 2,
                            verbose = TRUE),
-               .groups = "keep") %>%
+               .groups = "keep") |>
     left_join(paired_tests, by = "group")
   expect_equal(group_testing_tibble_less$SampleSizes,
                group_testing_tibble_less$total)
@@ -592,18 +592,18 @@ test_that("pairwise_comparisons_bin testing two groups", {
   id = c(1:26, 1:26)
   test_data <- tibble(x, group, id)
 
-  testing_stats_pre <- test_data %>%
-    filter(!is.na(x)) %>%
-    group_by(group) %>%
-    mutate(num_pos = sum(x), n = n()) %>%
-    group_by(group,num_pos, n) %>%
-    group_modify( ~ wilson_ci(.$x, .95)) %>% ungroup() %>%
+  testing_stats_pre <- test_data |>
+    filter(!is.na(x)) |>
+    group_by(group) |>
+    mutate(num_pos = sum(x), n = n()) |>
+    group_by(group,num_pos, n) |>
+    group_modify( ~ wilson_ci(.$x, .95)) |> ungroup() |>
     mutate(rr = paste0(num_pos, '/', n, ' = ',
                        stat_paste(mean * 100, lower * 100, upper * 100, digits = 1, suffix = '%')))
 
   testing_stats <- bind_cols(
-    testing_stats_pre %>% filter(group == 'a') %>% select(Group1 = group, Group1_rr = rr),
-    testing_stats_pre %>% filter(group == 'b') %>% select(Group2 = group, Group2_rr = rr))
+    testing_stats_pre |> filter(group == 'a') |> select(Group1 = group, Group1_rr = rr),
+    testing_stats_pre |> filter(group == 'b') |> select(Group2 = group, Group2_rr = rr))
 
 
   # testing multiple methods
@@ -624,20 +624,20 @@ test_that("pairwise_comparisons_bin testing two groups", {
                 })
 
   # Digits to 3
-  testing_stats_pre_3digits <- test_data %>%
-    filter(!is.na(x)) %>%
-    group_by(group) %>%
-    mutate(num_pos = sum(x), n = n()) %>%
-    group_by(group,num_pos, n) %>%
-    group_modify( ~ wilson_ci(.$x, .95)) %>% ungroup() %>%
+  testing_stats_pre_3digits <- test_data |>
+    filter(!is.na(x)) |>
+    group_by(group) |>
+    mutate(num_pos = sum(x), n = n()) |>
+    group_by(group,num_pos, n) |>
+    group_modify( ~ wilson_ci(.$x, .95)) |> ungroup() |>
     mutate(rr = paste0(num_pos, '/', n, ' = ',
                        stat_paste(mean * 100, lower * 100, upper * 100, digits = 3, suffix = '%')))
 
   testing_stats_3digits <- bind_cols(
-    testing_stats_pre_3digits %>%
-    filter(group == 'a') %>%
-    select(Group1 = group, Group1_rr = rr), testing_stats_pre_3digits %>%
-    filter(group == 'b') %>% select(Group2 = group, Group2_rr = rr))
+    testing_stats_pre_3digits |>
+    filter(group == 'a') |>
+    select(Group1 = group, Group1_rr = rr), testing_stats_pre_3digits |>
+    filter(group == 'b') |> select(Group2 = group, Group2_rr = rr))
 
   test_pasting <- paste_tbl_grp(data = testing_stats_3digits)
   names(test_pasting) <- c('Comparison', 'ResponseStats')
@@ -696,22 +696,22 @@ test_that("pairwise_comparisons_bin testing two groups", {
   # Paired data (mcnemar testing)
   paired_ids <- na.omit(test_data)$id[(duplicated(na.omit(test_data)$id))]
 
-  paired_stats_pre <- test_data %>%
-    filter(id %in% paired_ids) %>%
-    group_by(group) %>%
-    mutate(num_pos = sum(x), n = n()) %>%
-    group_by(group,num_pos, n) %>%
-    group_modify( ~ wilson_ci(.$x, .95)) %>% ungroup() %>%
+  paired_stats_pre <- test_data |>
+    filter(id %in% paired_ids) |>
+    group_by(group) |>
+    mutate(num_pos = sum(x), n = n()) |>
+    group_by(group,num_pos, n) |>
+    group_modify( ~ wilson_ci(.$x, .95)) |> ungroup() |>
     mutate(rr = paste0(num_pos, '/', n, ' = ', stat_paste(mean * 100,
                                                           lower * 100,
                                                           upper * 100,
                                                           digits = 1,
                                                           suffix = '%')))
 
-  paired_stats <- bind_cols(paired_stats_pre %>%
-                              filter(group == 'a') %>%
-                              select(Group1 = group, Group1_rr = rr), paired_stats_pre %>%
-                              filter(group == 'b') %>%
+  paired_stats <- bind_cols(paired_stats_pre |>
+                              filter(group == 'a') |>
+                              select(Group1 = group, Group1_rr = rr), paired_stats_pre |>
+                              filter(group == 'b') |>
                               select(Group2 = group, Group2_rr = rr))
 
 
@@ -752,18 +752,18 @@ test_that("pairwise_test_bin testing 3+ groups", {
   data("exampleData_BAMA")
 
 
-  testing_results <- exampleData_BAMA %>%
-    filter(visitno != 0) %>%
-    group_by(antigen, visitno, group) %>%
+  testing_results <- exampleData_BAMA |>
+    filter(visitno != 0) |>
+    group_by(antigen, visitno, group) |>
     summarise(rfraction = paste0(sum(response), "/", n()),
               ci = wilson_ci(response),
               r1 = sum(response),
               r0 = abs(sum(response - 1)),
-              .groups = "keep")  %>%
+              .groups = "keep")  |>
     pivot_wider(id_cols = c(antigen, visitno),
                 names_from = group,
                 names_prefix = "grp",
-                values_from = c(rfraction, ci, r0, r1)) %>%
+                values_from = c(rfraction, ci, r0, r1)) |>
     mutate(pval = ifelse(((r0_grp1 == 0 & r0_grp2 == 0) | (r1_grp1 == 0 & r1_grp2 == 0)),
                               1,
                               as.double(Exact::exact.test(matrix(c(r1_grp1,
@@ -791,11 +791,11 @@ test_that("pairwise_test_bin testing 3+ groups", {
                                   round_away_0(ci_grp2$lower*100, 1, trailing_zeros = TRUE),
                                   "%, ",
                                   round_away_0(ci_grp2$upper*100, 1, trailing_zeros = TRUE),
-                                  "%)"))  %>%
+                                  "%)"))  |>
     select(antigen, visitno, Comparison, ResponseStats, ResponseTest = pval, PerfectSeparation)
 
-  function_obj <- exampleData_BAMA %>%
-    group_by(antigen, visitno) %>%
+  function_obj <- exampleData_BAMA |>
+    group_by(antigen, visitno) |>
     group_modify(~ as.data.frame(pairwise_test_bin(x = .$response,
                                                    group = .$group,
                                                    method = 'barnard',
@@ -826,8 +826,8 @@ test_that("error checking", {
   id = c(1:26, 1:26)
 
   test_data <- data.frame(x, pair, id)
-  test_data_wide <- test_data %>%
-    pivot_wider(names_from = pair, values_from = x) %>%
+  test_data_wide <- test_data |>
+    pivot_wider(names_from = pair, values_from = x) |>
     drop_na()
 
   expect_error(
@@ -883,8 +883,8 @@ test_that("cor_test_pairs testing two groups", {
   id = c(1:26, 1:26, 1)
 
   test_data <- data.frame(x, group, id)
-  test_data_wide <- test_data[-length(x),] %>%
-    pivot_wider(names_from = group, values_from = x) %>%
+  test_data_wide <- test_data[-length(x),] |>
+    pivot_wider(names_from = group, values_from = x) |>
     drop_na()
 
 
@@ -900,7 +900,7 @@ test_that("cor_test_pairs testing two groups", {
     ),
     CorrEst = stats::cor(x = test_data_wide$a,
                        y = test_data_wide$b,
-                       method = 'spearman', use = 'pairwise.complete.obs') %>%
+                       method = 'spearman', use = 'pairwise.complete.obs') |>
       round_away_0(digits = 3, trailing_zeros = TRUE),
     CorrTest = cor_test(x = test_data_wide$a,
                         y = test_data_wide$b,
@@ -935,7 +935,7 @@ test_that("cor_test_pairs testing two groups", {
   testing_results5$CorrEst <- stats::cor(x = test_data_wide$a,
                                         y = test_data_wide$b,
                                         method = 'spearman',
-                                        use = 'pairwise.complete.obs') %>%
+                                        use = 'pairwise.complete.obs') |>
     round_away_0(digits = 5, trailing_zeros = TRUE)
 
   expect_equal(object = cor_test_pairs(x = test_data$x,
@@ -959,12 +959,12 @@ test_that("cor_test_pairs testing multiple groups", {
 
   test_single_comp <- function(data_in) {
 
-    test_data <- data_in %>%
-      filter(!is.na(x)) %>%
+    test_data <- data_in |>
+      filter(!is.na(x)) |>
       mutate(group = droplevels(group))
 
-    test_data_wide <- test_data %>%
-      pivot_wider(names_from = group, values_from = x) %>%
+    test_data_wide <- test_data |>
+      pivot_wider(names_from = group, values_from = x) |>
       drop_na()
 
     testing_results <- data.frame(
@@ -981,11 +981,11 @@ test_that("cor_test_pairs testing multiple groups", {
           paste0('ties in ', levels(test_data$group)[2]),
         TRUE ~ 'no ties'
       ),
-      CorrEst = ifelse(sum(!test_data_wide[,2, drop = TRUE] %>% duplicated) >= 3 &
-                         sum(!test_data_wide[,3, drop = TRUE] %>% duplicated) >= 3,
+      CorrEst = ifelse(sum(!test_data_wide[,2, drop = TRUE] |> duplicated()) >= 3 &
+                         sum(!test_data_wide[,3, drop = TRUE] |> duplicated()) >= 3,
         stats::cor(x = test_data_wide[,2, drop = TRUE],
                            y = test_data_wide[,3, drop = TRUE],
-                           method = 'spearman', use = 'pairwise.complete.obs') %>%
+                           method = 'spearman', use = 'pairwise.complete.obs') |>
         round_away_0(digits = 3, trailing_zeros = TRUE),
         NA),
       CorrTest = cor_test(x = test_data_wide[,2, drop = TRUE],
@@ -1016,15 +1016,15 @@ test_that("cor_test_pairs testing multiple groups", {
     }
   }
 
-  testing_results <- testData_BAMA %>%
-    group_by(group, visit) %>%
+  testing_results <- testData_BAMA |>
+    group_by(group, visit) |>
     group_modify(~test_all_comp(x = .x$magnitude,
                                 group = .x$antigen,
-                                id = .x$pubID) %>%
-                   as.data.frame)
+                                id = .x$pubID) |>
+                   as.data.frame())
 
-  group_testing_dt <- testData_BAMA %>%
-    group_by(group, visit) %>%
+  group_testing_dt <- testData_BAMA |>
+    group_by(group, visit) |>
     group_modify(~cor_test_pairs(x = .x$magnitude,
                                     pair = .x$antigen,
                                     id = .x$pubID,
@@ -1032,15 +1032,15 @@ test_that("cor_test_pairs testing multiple groups", {
                                     n_distinct_value = 3,
                                     digits = 3,
                                     trailing_zeros = TRUE,
-                                    verbose = FALSE) %>%
-                   as.data.frame)
+                                    verbose = FALSE) |>
+                   as.data.frame())
 
   expect_equal(object = group_testing_dt,
                expected = testing_results)
 
   expect_message(
-    object = testData_BAMA %>%
-      group_by(group, visit) %>%
+    object = testData_BAMA |>
+      group_by(group, visit) |>
       group_modify(~cor_test_pairs(x = .x$magnitude,
                                    pair = .x$antigen,
                                    id = .x$pubID,

--- a/tests/testthat/test_pretty_output_functions.R
+++ b/tests/testthat/test_pretty_output_functions.R
@@ -7,8 +7,8 @@ test_that("paste_tbl_grp testing various options (no errors)", {
 
   ## Creating Testing Dataset for Pasting
   data(exampleData_BAMA)
-  testing_dataset <- exampleData_BAMA %>%
-    group_by(visitno,antigen) %>%
+  testing_dataset <- exampleData_BAMA |>
+    group_by(visitno,antigen) |>
     summarise(
       Group1 = unique(group[group == 1]), Group2 = unique(group[group == 2]),
       Group1_n = length(magnitude[group == 1]), Group2_n = length(magnitude[group == 2]),
@@ -133,14 +133,14 @@ test_that("paste_tbl_grp testing various options (no errors)", {
                                      keep_all = FALSE))
   # Trying different group naming
   expect_equal(object = paste_tbl_grp(
-    data = testing_dataset %>%
+    data = testing_dataset |>
       select(Group_1 = Group1, Group_2 = Group2,
              Group_2_mean = Group2_mean, Group_1_mean = Group1_mean),
     first_name = 'Group_1', second_name = 'Group_2'),
                expected =  default_expected_results[, c('Comparison', 'mean_comparison')]
   )
   expect_equal(object = paste_tbl_grp(
-    data = testing_dataset %>%
+    data = testing_dataset |>
       select(`G.r/o|up_1` = Group1, Group_2 = Group2,
              Group_2_mean = Group2_mean, `G.r/o|up_1_mean` = Group1_mean),
     first_name = 'G.r/o|up_1', second_name = 'Group_2', keep_all = FALSE),
@@ -148,7 +148,7 @@ test_that("paste_tbl_grp testing various options (no errors)", {
                                                         'mean_comparison')]
   )
   expect_equal(object = paste_tbl_grp(
-    data = testing_dataset %>%
+    data = testing_dataset |>
       select(`Group-1` = Group1, `Group-12` = Group2,
              `Group-12_mean` = Group2_mean, `Group-1_mean` = Group1_mean),
     first_name = 'Group-1', second_name = 'Group-12'),
@@ -165,16 +165,16 @@ test_that("paste_tbl_grp testing various options (no errors)", {
   expect_error(object = paste_tbl_grp(data = testing_dataset, second_name = 'Group3'),
                regexp = 'Expecting one column named "Group3" in input dataset, but there are 0 present'
   )
-  expect_error(object = paste_tbl_grp(data = testing_dataset %>%
+  expect_error(object = paste_tbl_grp(data = testing_dataset |>
                                         select(-starts_with('Group1'))),
                regexp = 'Expecting one column named "Group1" in input dataset, but there are 0 present'
   )
   # Duplicate column names
   expect_error(object = paste_tbl_grp(
-    data = testing_dataset %>%
+    data = testing_dataset |>
       select(Group1, Group2, Group1_mean,
-             Group2_mean) %>%
-      bind_cols(testing_dataset %>% select(Group2_mean),
+             Group2_mean) |>
+      bind_cols(testing_dataset |> select(Group2_mean),
                 .name_repair = 'minimal')),
                regexp = 'Expecting one column named "Group2_mean" in input dataset, but there are 2 present'
   )

--- a/tests/testthat/test_statistical_tests_and_estimates.R
+++ b/tests/testthat/test_statistical_tests_and_estimates.R
@@ -506,7 +506,7 @@ test_that("test-binom_ci", {
   expect_equal(binom_ci(x), binom::binom.wilson(3, 5))
   expect_equal(binom_ci(as.logical(x)), binom::binom.wilson(3, 5))
   expect_equal(binom_ci(x, methods = 'all'),
-               binom::binom.confint(3, 5, methods = 'all')) %>% suppressWarnings
+               binom::binom.confint(3, 5, methods = 'all')) |> suppressWarnings()
   # testing edge cases
   expect_equal(binom_ci(rep(0, 50)), binom::binom.wilson(0, 50))
   expect_equal(binom_ci(rep(1, 50)), binom::binom.wilson(50, 50))

--- a/vignettes/Overview.Rmd
+++ b/vignettes/Overview.Rmd
@@ -156,7 +156,7 @@ str(exampleData_BAMA)
 ```{r, echo=FALSE}
 # Loading in example datasets
 exampleData_BAMA <- 
-  exampleData_BAMA %>% 
+  exampleData_BAMA |> 
   mutate(antigen = gsub('_', ' ', antigen))
 ```
 
@@ -176,7 +176,7 @@ increasing and positive, respectively.
 ```{r, echo=TRUE}
 
 # Making Testing Dataset
-testing_data <- exampleData_BAMA %>%
+testing_data <- exampleData_BAMA |>
   dplyr::filter(antigen == 'A1.con.env03 140 CF' & visitno == 1)
 
 ```
@@ -213,9 +213,9 @@ two_samp_bin_test(
   alternative = 'two.sided')
 
 # Calling test multiple times
-exampleData_BAMA %>% 
-  group_by(antigen, visitno) %>% 
-  filter(visitno != 0) %>% 
+exampleData_BAMA |> 
+  group_by(antigen, visitno) |> 
+  filter(visitno != 0) |> 
   summarise(p_val = two_samp_bin_test(response, group, method = 'barnard'), .groups = "drop")
 ```
 
@@ -243,9 +243,9 @@ two_samp_cont_test(
 )
 
 # Calling test multiple times
-exampleData_BAMA %>% 
-  group_by(antigen, visitno) %>% 
-  filter(visitno != 0) %>% 
+exampleData_BAMA |> 
+  group_by(antigen, visitno) |> 
+  filter(visitno != 0) |> 
   summarise(p_val = two_samp_cont_test(magnitude, group, method = 'wilcox'), .groups = "drop")
 ```
 
@@ -267,10 +267,10 @@ there are no ties, the exact method is used from `stats:cor.test`.
 ```{r, echo=TRUE, warning=FALSE}
 
 # Making Testing Dataset
-cor_testing_data <- exampleData_BAMA %>%
+cor_testing_data <- exampleData_BAMA |>
   dplyr::filter(antigen %in% c('A1.con.env03 140 CF', 'B.MN V3 gp70'),
                 visitno == 1,
-                group == 1) %>%
+                group == 1) |>
   tidyr::pivot_wider(id_cols = pubID,
                      names_from = antigen,
                      values_from = magnitude)
@@ -341,7 +341,7 @@ kableExtra::kable(
   linesep = "",
   col.names = c("P-values"),
   caption = 'Fancy P Values'
-) %>%
+) |>
   kableExtra::kable_styling(font_size = 8.5,
                             latex_options = "hold_position")
 
@@ -371,9 +371,9 @@ stat_paste(stat1 = 2.45, stat2 = 0.214, stat3 = 55.3,
 stat_paste(stat1 = 6.4864, stat2 = pretty_pvalues(0.0004, digits = 3), 
            digits = 3, bound_char = '(')
 
-exampleData_BAMA %>% 
-  filter(visitno == 1) %>%  
-  group_by(antigen, group) %>% 
+exampleData_BAMA |> 
+  filter(visitno == 1) |>  
+  group_by(antigen, group) |> 
   reframe(`Magnitude Info (Median [Range])` = 
             stat_paste(stat1 = median(magnitude), 
                        stat2 = min(magnitude),
@@ -398,22 +398,22 @@ Example of summary information to be pasted together (partial output):
 
 ```{r, echo=FALSE, warning=FALSE, size='tiny'}
 
-summary_info <- exampleData_BAMA %>%
-  filter(visitno == 1) %>%
-  mutate(group = paste0("Group", group)) %>%
-  group_by(antigen, group) %>%
+summary_info <- exampleData_BAMA |>
+  filter(visitno == 1) |>
+  mutate(group = paste0("Group", group)) |>
+  group_by(antigen, group) |>
   reframe(n = length(magnitude),
           mean = mean(magnitude),
           sd = sd(magnitude),
           median = median(magnitude),
           min = min(magnitude),
-          max = max(magnitude)) %>%
-  tidyr::pivot_longer(cols = n:max) %>%
-  tidyr::unite(var, group, name) %>%
-  tidyr::pivot_wider(names_from = var, values_from = value) %>%
+          max = max(magnitude)) |>
+  tidyr::pivot_longer(cols = n:max) |>
+  tidyr::unite(var, group, name) |>
+  tidyr::pivot_wider(names_from = var, values_from = value) |>
   mutate(Group1 = "Group 1", Group2 = "Group 2")
 
-summary_info %>%
+summary_info |>
   select(antigen,
          Group1_max,
          Group1_mean,
@@ -425,7 +425,7 @@ summary_info %>%
 
 ```{r, echo=TRUE, warning=FALSE}
 
-summary_table <-  summary_info %>%
+summary_table <-  summary_info |>
   paste_tbl_grp(
     vars_to_paste = c('n', 'mean_sd', 'median_min_max'),
     first_name = 'Group1',
@@ -437,8 +437,8 @@ kableExtra::kable(
   booktabs = TRUE,
   linesep = "",
   caption = 'Summary Information Comparison'
-) %>%
-  kableExtra::kable_styling(font_size = 6.5, latex_options = "hold_position") %>%
+) |>
+  kableExtra::kable_styling(font_size = 6.5, latex_options = "hold_position") |>
   kableExtra::footnote('Summary Information for Group 1 vs. Group 2, by Antigen and for Visit 1')
 ```
 
@@ -475,13 +475,13 @@ sample_df <- data.frame(
   outputVal = runif(7)
 )
 
-collapse_group_row(sample_df, x, y, z) %>%
+collapse_group_row(sample_df, x, y, z) |>
   kableExtra::kable(
     booktabs = TRUE,
     linesep = "",
     row.names = FALSE
-  ) %>%
-  kableExtra::row_spec(3, hline_after = TRUE) %>% 
+  ) |>
+  kableExtra::row_spec(3, hline_after = TRUE) |> 
   kableExtra::kable_styling(font_size = 8, latex_options = "hold_position")
 ```
 
@@ -506,7 +506,7 @@ x_example <- c(NA, sample(0:1, 50, replace = TRUE, prob = c(.75, .25)),
   sample(0:1, 50, replace = TRUE, prob = c(.25, .75)))
 group_example <- c(rep(1, 25), NA, rep(2, 25), rep(3, 25), rep(4, 25))
 
-pairwise_test_bin(x_example, group_example) %>% 
+pairwise_test_bin(x_example, group_example) |> 
   rename(Separation = 'PerfectSeparation')
 ```
 
@@ -516,17 +516,17 @@ Group comparison example using `pairwise_test_bin`:
 ```{r, echo=TRUE, warning=FALSE, results='asis'}
 
 ## Group Comparison
-group_testing <- exampleData_ICS %>%
-  filter(Population == 'IFNg Or IL2' & Group != 4) %>%
-  group_by(Stim, Visit) %>%
+group_testing <- exampleData_ICS |>
+  filter(Population == 'IFNg Or IL2' & Group != 4) |>
+  group_by(Stim, Visit) |>
   group_modify( ~ as.data.frame(
     pairwise_test_bin(x = .$response, group = .$Group,
                       method = 'barnard', alternative = 'less',
                       num_needed_for_test = 3, digits = 1,
                       latex_output = TRUE, verbose = FALSE
                       )
-  )) %>%
-  ungroup() %>%
+  )) |>
+  ungroup() |>
   # Getting fancy p values
   mutate(
     ResponseTest = pretty_pvalues(
@@ -542,11 +542,11 @@ group_testing <- exampleData_ICS %>%
 
 kableExtra::kable( group_testing, escape = FALSE, booktabs = TRUE,
   linesep = "", caption = 'Response Rate Comparisons Across Groups'
-) %>%
+) |>
   kableExtra::kable_styling(
     font_size = 6.5,
     latex_options = c("hold_position", "scale_down")
-    ) %>%
+    ) |>
   kableExtra::collapse_rows(c(1:2),
                             row_group_label_position = 'identity',
                             latex_hline = 'full')
@@ -560,23 +560,23 @@ Time point comparison example (paired) using `pairwise_test_bin()`:
 ```{r, echo=TRUE, warning=FALSE, results='asis'}
 
 ## Timepoint Comparison
-timepoint_testing <- exampleData_ICS %>%
-  filter(Population == 'IFNg Or IL2' & Group != 4) %>% 
-  group_by(Stim, Group) %>%
+timepoint_testing <- exampleData_ICS |>
+  filter(Population == 'IFNg Or IL2' & Group != 4) |> 
+  group_by(Stim, Group) |>
   group_modify(~ as.data.frame(
     pairwise_test_bin(x = .$response, group = .$Visit, id = .$pubID,
                       method = 'mcnemar', num_needed_for_test = 3, digits = 1,
-                      latex_output = TRUE, verbose = FALSE))) %>% 
-  ungroup() %>% 
+                      latex_output = TRUE, verbose = FALSE))) |> 
+  ungroup() |> 
   # Getting fancy p values
   mutate(ResponseTest = pretty_pvalues(ResponseTest, output_type = 'latex', 
                                        sig_alpha = .1, background = 'yellow'))
 
 
 kableExtra::kable(timepoint_testing, escape = FALSE, booktabs = TRUE, 
-                  caption = 'Response Rate Comparisons Across Visits') %>% 
+                  caption = 'Response Rate Comparisons Across Visits') |> 
   kableExtra::kable_styling(font_size = 6.5, 
-                            latex_options = c("hold_position","scale_down")) %>% 
+                            latex_options = c("hold_position","scale_down")) |> 
   kableExtra::collapse_rows(c(1:2), row_group_label_position = 'identity', 
                             latex_hline = 'full')
 ```
@@ -596,7 +596,7 @@ set.seed(1)
 x_example <- c(NA, rnorm(50), rnorm(50, mean = 5))
 group_example <- c(rep(1, 25), rep(2, 25), rep(3, 25), rep(4, 25), NA)
 
-pairwise_test_cont(x_example, group_example, digits = 1) %>% 
+pairwise_test_cont(x_example, group_example, digits = 1) |> 
   rename(Separation = 'PerfectSeparation')
 ```
 
@@ -607,26 +607,26 @@ Group comparison example using `pairwise_test_cont()`:
 ```{r, echo=TRUE, warning=FALSE, results='asis'}
 
 ## Group Comparison
-group_testing <- exampleData_ICS %>%
-  filter(Population == 'IFNg Or IL2' & Group != 4) %>% 
-  group_by(Stim, Visit) %>%
+group_testing <- exampleData_ICS |>
+  filter(Population == 'IFNg Or IL2' & Group != 4) |> 
+  group_by(Stim, Visit) |>
   group_modify(~ as.data.frame(
     pairwise_test_cont(x = pmax(.$PercentCellNet, 0.00001), group = .$Group,
                       method = 'wilcox', paired = FALSE, 
                       alternative = 'greater', num_needed_for_test = 3, 
-                      digits = 3, log10_stats = TRUE))) %>% 
-   ungroup() %>% 
+                      digits = 3, log10_stats = TRUE))) |> 
+   ungroup() |> 
   # Getting fancy p values
   mutate(MagnitudeTest = pretty_pvalues(
     MagnitudeTest, output_type = 'latex', 
     sig_alpha = .1, background = 'yellow')
-  ) %>% 
+  ) |> 
   rename("Median (Range)" = Median_Min_Max, 'Mean (SD) (log10)' = log_Mean_SD)
 
 kableExtra::kable(group_testing, escape = FALSE, booktabs = TRUE, 
-                  caption = 'Magnitude Comparisons Across Groups') %>% 
+                  caption = 'Magnitude Comparisons Across Groups') |> 
   kableExtra::kable_styling(font_size = 6.5, 
-                            latex_options = c("hold_position","scale_down")) %>% 
+                            latex_options = c("hold_position","scale_down")) |> 
   kableExtra::collapse_rows(c(1:2), 
                             row_group_label_position = 'identity', 
                             latex_hline = 'full')
@@ -640,29 +640,29 @@ Time point comparison example (paired) using `pairwise_test_cont()`:
 ```{r, echo=TRUE, warning=FALSE, results='asis'}
 
 ## Timepoint Comparison
-timepoint_testing <- exampleData_ICS %>%
-  filter(Population == 'IFNg Or IL2' & Group != 4) %>% 
-  group_by(Stim, Group) %>%
+timepoint_testing <- exampleData_ICS |>
+  filter(Population == 'IFNg Or IL2' & Group != 4) |> 
+  group_by(Stim, Group) |>
   group_modify(~ as.data.frame(
     pairwise_test_cont(x =  pmax(.$PercentCellNet, 0.00001), group = .$Visit, 
                        id = .$pubID, method = 'wilcox', paired = TRUE, 
                        num_needed_for_test = 3, 
-                       digits = 3, log10_stats = TRUE))) %>% 
-   ungroup() %>% 
+                       digits = 3, log10_stats = TRUE))) |> 
+   ungroup() |> 
   # Getting fancy p values
   mutate(MagnitudeTest = pretty_pvalues(
     MagnitudeTest, output_type = 'latex', 
     sig_alpha = .1, background = 'yellow')
-    ) %>% 
+    ) |> 
   rename("Median (Range)" = Median_Min_Max, 'Mean (SD) (log10)' = log_Mean_SD)
 
 
 kableExtra::kable(timepoint_testing, 
                   escape = FALSE, 
                   booktabs = TRUE, 
-                  caption = 'Magnitude Comparisons Across Visits') %>% 
+                  caption = 'Magnitude Comparisons Across Visits') |> 
   kableExtra::kable_styling(font_size = 6.5, 
-                            latex_options = c("hold_position","scale_down")) %>% 
+                            latex_options = c("hold_position","scale_down")) |> 
   kableExtra::collapse_rows(c(1:2), 
                             row_group_label_position = 'identity', 
                             latex_hline = 'full')
@@ -695,28 +695,28 @@ Correlation comparisons using `cor_test_pairs`:
 
 ```{r, echo=TRUE, warning=FALSE, results='asis'}
 ## Antigen Correlations
-antigen_testing <- exampleData_BAMA %>%
+antigen_testing <- exampleData_BAMA |>
   filter(antigen %in% c('B.63521 D11gp120/293F', 
                         'B.con.env03 140 CF',
                         'B.MN V3 gp70') & 
-           group != 4) %>% 
-  group_by(group, visitno) %>%
+           group != 4) |> 
+  group_by(group, visitno) |>
   group_modify(~ as.data.frame(
     cor_test_pairs(x = .x$magnitude,
                       pair = .x$antigen,
                       id = .x$pubID,
                       method = 'spearman',
-                      n_distinct_value = 3))) %>% 
-  ungroup() %>% 
+                      n_distinct_value = 3))) |> 
+  ungroup() |> 
   # Getting fancy p values
   mutate(CorrTest = pretty_pvalues(CorrTest, output_type = 'latex', 
-                                   sig_alpha = .1, background = 'yellow')) %>% 
+                                   sig_alpha = .1, background = 'yellow')) |> 
   rename("Corr P Value" = CorrTest)
 
 kableExtra::kable(antigen_testing, escape = FALSE, 
-                  booktabs = TRUE, caption = 'Correlations between Antigen') %>% 
+                  booktabs = TRUE, caption = 'Correlations between Antigen') |> 
   kableExtra::kable_styling(font_size = 6.5, 
-                            latex_options = c("hold_position","scale_down")) %>% 
+                            latex_options = c("hold_position","scale_down")) |> 
   kableExtra::collapse_rows(c(1:2), 
                             row_group_label_position = 'identity', 
                             latex_hline = 'full')
@@ -739,10 +739,10 @@ breadth (MB) curves, and cumulative plots.
 
 #Potency-breadth curves
 plot_data <-
- CAVD812_mAB %>%
-  filter(virus != 'SVA-MLV') %>% 
-  tidyr::pivot_longer(cols = c(ic50, ic80)) %>% 
-  dplyr::group_by(name, product) %>%
+ CAVD812_mAB |>
+  filter(virus != 'SVA-MLV') |> 
+  tidyr::pivot_longer(cols = c(ic50, ic80)) |> 
+  dplyr::group_by(name, product) |>
   dplyr::group_modify(~ create_step_curve(x = pmin(.x$value, 100), 
                                           event = as.numeric(.x$value < 50),
                                           flip_surv = TRUE, flip_top_x = 100)) 
@@ -763,12 +763,12 @@ options to include response status and have logged transformation for AUC-MB
 calculation.
 
 ```{r, echo=TRUE, warning=FALSE, fig.cap='BAMA Magnitude Breadth curves'}
-data_here <- exampleData_BAMA %>% filter(visitno == 2)
+data_here <- exampleData_BAMA |> filter(visitno == 2)
 
-group_results <- data_here %>% dplyr::group_by(group) %>%
+group_results <- data_here |> dplyr::group_by(group) |>
   dplyr::group_modify(~ mb_results(magnitude = .x$magnitude , 
                                    response = .x$response))
-ind_results <-  data_here %>% dplyr::group_by(group, pubID) %>%
+ind_results <-  data_here |> dplyr::group_by(group, pubID) |>
   dplyr::group_modify(~ mb_results(magnitude = .x$magnitude , 
                                    response = .x$response))
 ggplot2::ggplot(
@@ -837,7 +837,7 @@ kableExtra::kable(
   booktabs = TRUE,
   linesep = '',
   caption = "Reproducibility Software Session Information"
-) %>%
+) |>
   kableExtra::kable_styling(font_size = 8, latex_options = "hold_position")
 
 ```
@@ -849,7 +849,7 @@ kableExtra::kable(
   booktabs = TRUE,
   linesep = '',
   caption = "Reproducibility Software Package Version Information"
-) %>%
+) |>
   kableExtra::kable_styling(font_size = 8, latex_options = "hold_position")
 
 ```


### PR DESCRIPTION
The old `statsrv` with R 4.0.4 has finally been retired, and I asked around to confirm that people in VISC and HVTN are no longer using R that old. It sounds like everyone is now on rsrv or newer.

How new of an R version should we require?  Well, the tidyverse currently supports R as old as R 4.1.0 as part of their policy of supporting an approximately 5-major-version (~5-year) lookback:

https://github.com/tidyverse/dplyr/blob/main/DESCRIPTION

Which seems reasonable to me.

So, this PR:
- drops the statsrv-mimic CI runner for R 4.0.4, but still keeps a runner on R 4.1.0 with statsrv's old pandoc version (2.11.4).
- adds an explicit `rsrv`-mimic CI runner using R 4.4.2 and pandoc 3.2.
- adds the R >= 4.1.0 dependency to the VISCfunctions DESCRIPTION.  We won't be able to install the new version of VISCfunctions on R older than that.
- switches the package to using the base pipe.

Closes #117 