### PR TITLE
Update pkgdown site formatting

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,3 +2,64 @@ url: https://fredhutch.github.io/VISCfunctions/
 template:
   bootstrap: 5
 
+navbar:
+  structure:
+    left:
+      - home
+      - functions   # replaces "reference"
+      - vignettes   # replaces "articles"
+      - news        # replaces "changelog"
+  components:
+    functions:
+      text: "Functions and Datasets"
+      desc: "All fuunctions and datasets made available by VISCfunctions"
+      href: reference/index.html
+    vignettes:
+      text: "Vignettes"
+      href: articles/index.html
+    news:
+      text: "News"
+      href: news/index.html
+
+
+reference:
+  - title: "Statistical Tests"
+    desc: "Formal hypothesis testing and p-value computations"
+    contents:
+      - two_samp_bin_test
+      - two_samp_cont_test
+      - cor_test
+      - pairwise_test_bin
+      - pairwise_test_cont
+      - cor_test_pairs
+      - binom_ci
+      - wilson_ci
+
+  - title: "Survival and Magnitude Breadth"
+    contents:
+      - create_step_curve
+      - mb_results
+      - trapz_sorted
+
+  - title: "Output Formatting for PDF and Word"
+    contents:
+      - paste_tbl_grp
+      - pretty_pvalues
+      - stat_paste
+      - escape
+      - collapse_group_row
+      - round_away_0
+
+  - title: "Utility Functions"
+    contents:
+      - get_full_name
+      - get_session_info
+      - shorten_git_hash
+
+  - title: "Example Datasets"
+    contents:
+      - exampleData_BAMA
+      - exampleData_ICS
+      - exampleData_NAb
+      - CAVD812_mAB
+      - G001_Bcell_flow_seq_PBMC


### PR DESCRIPTION
Updates pkgdown site formatting by changing some of the tab headers, and grouping VISCfunctions objects into categories (example datasets, statistical functions, etc.)

Related to https://github.com/FredHutch/VISCfunctions/issues/136

Split off from #125 for modularity and ease of review