### PR TITLE
Bugfix for round_away_0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Improve documentation for datasets and fix typos in various documentation files (#148)
 * Minor Changes:
   * Update `Overview()` to include new `Median_Quartiles` (#99)
+* Fix hardcoded floating point issues causing unexpected behavior in `round_away_0()` (#156)
 
 # VISCfunctions 1.3.1
 

--- a/R/statistical_tests_and_estimates.R
+++ b/R/statistical_tests_and_estimates.R
@@ -32,7 +32,11 @@ round_away_0 <- function(x, digits = 0, trailing_zeros = FALSE){
   .check_numeric_input(x, allow_NA = TRUE)
   .check_numeric_input(digits, lower_bound = 0, upper_bound = 14, scalar = TRUE, whole_num = TRUE)
 
-  rounded_vals <- sign(x) * round(abs(x) + 1e-15, digits)
+  # inspired by tidytlg::roundSAS()
+  z <- abs(x) * 10^digits
+  z <- z + 0.5 + sqrt(.Machine$double.eps)
+  z <- trunc(z) / 10 ^ digits
+  rounded_vals <- ifelse(! is.na(z) & z > 0, z * sign(x), z)
 
   if (trailing_zeros) {
     # Need to exclude NAs when doing formatting

--- a/R/statistical_tests_and_estimates.R
+++ b/R/statistical_tests_and_estimates.R
@@ -8,7 +8,7 @@
 #' @return if \code{trailing_zeros = TRUE} returns a character vector of rounded values with trailing zeros, otherwise returns a numeric vector of rounded values.
 #' @details
 #'
-#' \code{round_away_0} is not designed for use at precision levels <= 1e-15
+#' \code{round_away_0} is not designed for use at precision levels <= 1e-15 or on numbers with many digits to the left of the rounded digit
 #'
 #' @examples
 #'

--- a/man/VISCfunctions-package.Rd
+++ b/man/VISCfunctions-package.Rd
@@ -5,7 +5,7 @@
 \alias{VISCfunctions-package}
 \title{VISCfunctions: VISCfunctions}
 \description{
-Statistical, data processing, and annotation functions for VISC.
+Statistical, data processing, and annotation functions for VISC statisticians and programmers.
 }
 \seealso{
 Useful links:
@@ -22,7 +22,8 @@ Authors:
 \itemize{
   \item Dave Slager \email{dslager@fredhutch.org} (\href{https://orcid.org/0000-0003-2525-2039}{ORCID})
   \item Kellie MacPhee \email{kmacphee@fredhutch.org} (\href{https://orcid.org/0009-0008-0993-4009}{ORCID})
-  \item Gabrielle Lemire \email{glemire@fredhutch.org}
+  \item Alicia Sato \email{asato@fredhutch.org} (\href{https://orcid.org/0000-0001-8371-8007}{ORCID})
+  \item Gabrielle Lemire \email{glemire@fredhutch.org} (\href{https://orcid.org/0009-0008-3813-2523}{ORCID})
   \item Claudio Yurdadon \email{cyurdado@fredhutch.org} (\href{https://orcid.org/0000-0002-4928-2737}{ORCID})
   \item Monica Gerber
   \item Celia Mahoney

--- a/man/VISCfunctions.Rd
+++ b/man/VISCfunctions.Rd
@@ -5,7 +5,7 @@
 \alias{VISCfunctions}
 \title{VISCfunctions: VISC STP/SRA functions}
 \description{
-Statistical, data processing, and annotation functions for VISC.
+Statistical, data processing, and annotation functions for VISC statisticians and programmers.
 }
 \seealso{
 Useful links:
@@ -22,7 +22,8 @@ Authors:
 \itemize{
   \item Dave Slager \email{dslager@fredhutch.org} (\href{https://orcid.org/0000-0003-2525-2039}{ORCID})
   \item Kellie MacPhee \email{kmacphee@fredhutch.org} (\href{https://orcid.org/0009-0008-0993-4009}{ORCID})
-  \item Gabrielle Lemire \email{glemire@fredhutch.org}
+  \item Alicia Sato \email{asato@fredhutch.org} (\href{https://orcid.org/0000-0001-8371-8007}{ORCID})
+  \item Gabrielle Lemire \email{glemire@fredhutch.org} (\href{https://orcid.org/0009-0008-3813-2523}{ORCID})
   \item Claudio Yurdadon \email{cyurdado@fredhutch.org} (\href{https://orcid.org/0000-0002-4928-2737}{ORCID})
   \item Monica Gerber
   \item Celia Mahoney

--- a/man/round_away_0.Rd
+++ b/man/round_away_0.Rd
@@ -20,7 +20,7 @@ if \code{trailing_zeros = TRUE} returns a character vector of rounded values wit
 round_away_0 takes a numeric vector, rounds them to a specified digit amount using the round away from 0 method for ties (i.e. 1.5). This is the SAS method for rounding.
 }
 \details{
-\code{round_away_0} is not designed for use at precision levels <= 1e-15
+\code{round_away_0} is not designed for use at precision levels <= 1e-15 or on numbers with many digits to the left of the rounded digit
 }
 \examples{
 

--- a/tests/testthat/test_pretty_output_functions.R
+++ b/tests/testthat/test_pretty_output_functions.R
@@ -1,5 +1,15 @@
 context("pretty_output_functions")
 
+# helper to collapse whitespace and trim leading/trailing whitespace
+norm_ws <- function(x) {
+  if (is.character(x)) {
+    x <- gsub("\\s+", " ", x, perl = TRUE)   # collapse runs of whitespace to single space
+    trimws(x)
+  } else {
+    x
+  }
+}
+
 
 # test paste_tbl_grp
 test_that("paste_tbl_grp testing various options (no errors)", {
@@ -236,14 +246,14 @@ test_that("pretty_pvalues testing various options (no errors)", {
 
   # testing different outputs
 
-  expect_equal(object = pretty_pvalues(c(0.00000001, NA, 0.05, 1), digits = 3,
-                                       trailing_zeros = T, italic = T, output_type = "html"),
-               expected = c("<span style=\"  font-style: italic;   \" ><0.001</span>",
+  expect_equal(object = norm_ws(pretty_pvalues(c(0.00000001, NA, 0.05, 1), digits = 3,
+                                               trailing_zeros = T, italic = T, output_type = "html")),
+               expected = c(norm_ws("<span style=\"  font-style: italic;   \" ><0.001</span>"),
                             "---", "0.050", "1.000"))
-  expect_equal(object = pretty_pvalues(c(0.00000001, NA, 0.05, 1), digits = 3,
+  expect_equal(object = norm_ws(pretty_pvalues(c(0.00000001, NA, 0.05, 1), digits = 3,
                                        trailing_zeros = T, bold = T,
-                                       italic = T, output_type = "html"),
-               expected = c("<span style=\" font-weight: bold; font-style: italic;   \" ><0.001</span>",
+                                       italic = T, output_type = "html")),
+               expected = c(norm_ws("<span style=\" font-weight: bold; font-style: italic;   \" ><0.001</span>"),
                             "---", "0.050", "1.000"))
 
   expect_equal(object = pretty_pvalues(c(0.00000001, NA, 0.05, 1), digits = 3,

--- a/tests/testthat/test_pretty_output_functions.R
+++ b/tests/testthat/test_pretty_output_functions.R
@@ -1,6 +1,6 @@
 context("pretty_output_functions")
 
-normalize_ws <- function(x) gsub("\\s+", " ", trimws(x))
+remove_ws <- function(x) gsub("\\s+", "", trimws(x))
 
 
 # test paste_tbl_grp
@@ -240,20 +240,20 @@ test_that("pretty_pvalues testing various options (no errors)", {
 
   test_that("pretty_pvalues html output (italic)", {
     expect_equal(
-      object = normalize_ws(pretty_pvalues(c(0.00000001, NA, 0.05, 1), digits = 3,
-                                           trailing_zeros = T, italic = T, output_type = "html")),
-      expected = normalize_ws(c("<span style=\" font-style: italic; \" ><0.001</span>",
-                                "---", "0.050", "1.000"))
+      object = remove_ws(pretty_pvalues(c(0.00000001, NA, 0.05, 1), digits = 3,
+                                        trailing_zeros = T, italic = T, output_type = "html")),
+      expected = c("<spanstyle=\"font-style:italic;\"><0.001</span>",
+                   "---", "0.050", "1.000")
     )
   })
 
   test_that("pretty_pvalues html output (bold + italic)", {
     expect_equal(
-      object = normalize_ws(pretty_pvalues(c(0.00000001, NA, 0.05, 1), digits = 3,
-                                           trailing_zeros = T, bold = T,
-                                           italic = T, output_type = "html")),
-      expected = normalize_ws(c("<span style=\" font-weight: bold; font-style: italic; \" ><0.001</span>",
-                                "---", "0.050", "1.000"))
+      object = remove_ws(pretty_pvalues(c(0.00000001, NA, 0.05, 1), digits = 3,
+                                        trailing_zeros = T, bold = T,
+                                        italic = T, output_type = "html")),
+      expected = c("<spanstyle=\"font-weight:bold;font-style:italic;\"><0.001</span>",
+                   "---", "0.050", "1.000")
     )
   })
 

--- a/tests/testthat/test_pretty_output_functions.R
+++ b/tests/testthat/test_pretty_output_functions.R
@@ -1,14 +1,6 @@
 context("pretty_output_functions")
 
-# helper to collapse whitespace and trim leading/trailing whitespace
-norm_ws <- function(x) {
-  if (is.character(x)) {
-    x <- gsub("\\s+", " ", x, perl = TRUE)   # collapse runs of whitespace to single space
-    trimws(x)
-  } else {
-    x
-  }
-}
+normalize_ws <- function(x) gsub("\\s+", " ", trimws(x))
 
 
 # test paste_tbl_grp
@@ -246,15 +238,24 @@ test_that("pretty_pvalues testing various options (no errors)", {
 
   # testing different outputs
 
-  expect_equal(object = norm_ws(pretty_pvalues(c(0.00000001, NA, 0.05, 1), digits = 3,
-                                               trailing_zeros = T, italic = T, output_type = "html")),
-               expected = c(norm_ws("<span style=\"  font-style: italic;   \" ><0.001</span>"),
-                            "---", "0.050", "1.000"))
-  expect_equal(object = norm_ws(pretty_pvalues(c(0.00000001, NA, 0.05, 1), digits = 3,
-                                       trailing_zeros = T, bold = T,
-                                       italic = T, output_type = "html")),
-               expected = c(norm_ws("<span style=\" font-weight: bold; font-style: italic;   \" ><0.001</span>"),
-                            "---", "0.050", "1.000"))
+  test_that("pretty_pvalues html output (italic)", {
+    expect_equal(
+      object = normalize_ws(pretty_pvalues(c(0.00000001, NA, 0.05, 1), digits = 3,
+                                           trailing_zeros = T, italic = T, output_type = "html")),
+      expected = normalize_ws(c("<span style=\" font-style: italic; \" ><0.001</span>",
+                                "---", "0.050", "1.000"))
+    )
+  })
+
+  test_that("pretty_pvalues html output (bold + italic)", {
+    expect_equal(
+      object = normalize_ws(pretty_pvalues(c(0.00000001, NA, 0.05, 1), digits = 3,
+                                           trailing_zeros = T, bold = T,
+                                           italic = T, output_type = "html")),
+      expected = normalize_ws(c("<span style=\" font-weight: bold; font-style: italic; \" ><0.001</span>",
+                                "---", "0.050", "1.000"))
+    )
+  })
 
   expect_equal(object = pretty_pvalues(c(0.00000001, NA, 0.05, 1), digits = 3,
                                        trailing_zeros = T, italic = T,

--- a/tests/testthat/test_statistical_tests_and_estimates.R
+++ b/tests/testthat/test_statistical_tests_and_estimates.R
@@ -59,7 +59,46 @@ test_that("round_away_0 testing various options (no errors)", {
 
 })
 
+test_that("round_away_0 handles floating point exceptions", {
 
+  # Jin's reprex
+   expect_equal(
+     round_away_0(11:20 + .25, digits = 1),
+     11:20 + .3
+   )
+
+  # Moni's tests
+
+  # set base2 integers (plus 0)
+  base2_ints <- c(0, 2^(0:16))
+
+  # add half rounding units
+  make_test_vals <- function(int_vals, frac_str) {
+    as.numeric(paste0(format(int_vals, scientific = FALSE), frac_str))
+  }
+
+  round0 <- make_test_vals(base2_ints, ".5")
+  round1 <- make_test_vals(base2_ints, ".05")
+  round2 <- make_test_vals(base2_ints, ".005")
+  round3 <- make_test_vals(base2_ints, ".0005")
+  round4 <- make_test_vals(base2_ints, ".00005")
+
+  #  round round<n> values and subtract base numbers
+  # correct result should be non-zero (indicates rounding away from 0)
+  tests <- data.frame(
+    base2_int = base2_ints,
+    r0 = round_away_0(round0, 0) - base2_ints,
+    r1 = round_away_0(round1, 1) - base2_ints,
+    r2 = round_away_0(round2, 2) - base2_ints,
+    r3 = round_away_0(round3, 3) - base2_ints,
+    r4 = round_away_0(round4, 4) - base2_ints
+  )
+
+  expect_true(
+    all(sapply(tests[2:5], function(x) all(x > 0)))
+  )
+
+})
 
 
 # test two_samp_cont_test


### PR DESCRIPTION
Fix the rounding issues identified by Jin and Moni. Due to floating point arithmetic, rounding inconsistencies may still occur but they are now limited to numeric inputs with many digits to the left of the rounded digit.

The changes relevant to the bugfix are in these 2 files:
- R/statistical_tests_and_estimates.R
- tests/testthat/test_statistical_tests_and_estimates.R